### PR TITLE
Move to event listener instead of onerror for wider compatability

### DIFF
--- a/src/ClientErrorCollector.ts
+++ b/src/ClientErrorCollector.ts
@@ -101,35 +101,27 @@ export default class ClientErrorCollector {
 				if (window.onerror) {
 					oldonerror = (<any> window)[CLIENT_OLD_ONERROR_KEY] = window.onerror;
 				}
-				window.onerror = function (message, source, lineno, colno, error) {
-					const errorObj: ClientError = {
-						message: message,
-						source: source,
-						lineno: lineno,
-						colno: colno
-					};
 
-					if (error) {
-						errorObj.error = {
-							message: error.message,
-							name: error.name,
-							stack: error.stack
-						};
-					}
+				function errorListener(evt: ErrorEvent) {
+					const { message, filename, lineno, colno, error = {} } = evt;
+					const { stack = '', name = 'Error' } = error;
+					errorStack.push({
+						message,
+						source: filename,
+						lineno,
+						colno,
+						error: {
+							message: error.message || message,
+							name,
+							stack
+						}
+					});
+				}
 
-					errorStack.push(errorObj);
+				window.addEventListener('error', errorListener);
 
-					if (oldonerror) {
-						oldonerror.call(undefined, message, source, lineno, colno, error);
-					}
-				};
 				(<any> window)['__intern_error_helper_finish'] = function () {
-					if (typeof (<any> window)[CLIENT_OLD_ONERROR_KEY] !== 'undefined') {
-						window.onerror = (<any> window)[CLIENT_OLD_ONERROR_KEY];
-					}
-					else {
-						delete window.onerror;
-					}
+					window.removeEventListener('error', errorListener);
 					const errorStack = (<any> window)[CLIENT_ERROR_STACK_KEY];
 					delete (<any> window)[CLIENT_ERROR_STACK_KEY];
 					return JSON.stringify(errorStack);

--- a/src/ClientErrorCollector.ts
+++ b/src/ClientErrorCollector.ts
@@ -39,6 +39,7 @@ export default class ClientErrorCollector {
 						switch (result.error.name) {
 						case 'EvalError':
 							e = new EvalError(result.error.message);
+							break;
 						case 'RangeError':
 							e = new RangeError(result.error.message);
 							break;

--- a/tests/functional/ClientErrorCollector.ts
+++ b/tests/functional/ClientErrorCollector.ts
@@ -28,7 +28,7 @@ registerSuite({
 				assert.isNumber(result.lineno);
 				assert.isObject(result.error);
 				if (result.error) {
-					assert.strictEqual(result.error.message, 'Ooops...');
+					assert.include(result.error.message, 'Ooops...');
 					assert.strictEqual(result.error.name, 'Error');
 				}
 			});

--- a/tests/intern-saucelabs.ts
+++ b/tests/intern-saucelabs.ts
@@ -1,11 +1,11 @@
 export * from './intern';
 
 export const environments = [
-	{ browserName: 'internet explorer', version: [ '10.0', '11.0' ], platform: 'Windows 7' },
+	{ browserName: 'internet explorer', version: '11.0', platform: 'Windows 7' },
 	{ browserName: 'microsoftedge', platform: 'Windows 10' },
 	{ browserName: 'firefox', platform: 'Windows 10' },
 	{ browserName: 'chrome', platform: 'Windows 10' },
-	{ browserName: 'safari', version: '9', platform: 'OS X 10.11' },
+	{ browserName: 'safari', version: '10', platform: 'OS X 10.12' },
 	// Andriod causing issues when run from travis
 	// { browserName: 'android', deviceName: 'Google Nexus 7 HD Emulator' },
 	{ browserName: 'iphone', version: '9.3' }

--- a/tests/unit/ClientErrorCollector.ts
+++ b/tests/unit/ClientErrorCollector.ts
@@ -1,0 +1,174 @@
+import * as assert from 'intern/chai!assert';
+import * as registerSuite from 'intern!object';
+import ClientErrorCollector from '../../src/ClientErrorCollector';
+// import * as Promise from 'dojo/Promise';
+import * as Command from 'leadfoot/Command';
+
+let resultString = '';
+let lastResult: any;
+
+const mockRemote: Command<void> = <any> {
+	execute(...args: any[]) {
+		return mockRemote;
+	},
+
+	then(executor: (arg: any) => any) {
+		if (Array.isArray(lastResult)) {
+			lastResult = executor(lastResult);
+		}
+		else {
+			lastResult = executor(resultString);
+		}
+		return mockRemote;
+	}
+};
+
+registerSuite({
+	name: 'ClientErrorCollector',
+
+	'init()': {
+		'invocation'() {
+			const collector = new ClientErrorCollector(mockRemote);
+			collector.init()
+				.execute(() => {}, []);
+		},
+
+		'already init throws'() {
+			const collector = new ClientErrorCollector(mockRemote);
+			collector.init();
+			assert.throws(() => {
+				collector.init();
+			}, Error, 'ClientErrorCollector already initialised');
+		}
+	},
+
+	'finish()': {
+		'inocation'() {
+			const collector = new ClientErrorCollector(mockRemote);
+			resultString = '[]';
+			collector.init()
+				.then(() => {
+					collector.finish();
+					assert.isArray(lastResult);
+					assert.lengthOf(lastResult, 0);
+				});
+		},
+
+		'errors returned'() {
+			const collector = new ClientErrorCollector(mockRemote);
+			resultString = '[{"message":"Ooops...","source":"somefile.js","lineno":10,"colno":10,"error":{"message":"Ooops...","name":"TypeError","stack":""}}]';
+			collector.init()
+				.then(() => {
+					collector.finish();
+					assert.isArray(lastResult);
+					assert.lengthOf(lastResult, 1);
+					const [ result ] = lastResult;
+					assert.isObject(result);
+					assert.strictEqual(result.message, 'Ooops...');
+				});
+		},
+
+		'without init throws'() {
+			const collector = new ClientErrorCollector(mockRemote);
+			assert.throws(() => {
+				collector.finish();
+			}, Error, 'ClientErrorCollector not initialised');
+		}
+	},
+
+	'assertNoErrors()': {
+		'no errors'() {
+			const collector = new ClientErrorCollector(mockRemote);
+			resultString = '[]';
+			lastResult = undefined;
+			collector.init()
+				.then(() => {
+					collector.assertNoErrors();
+				});
+		},
+
+		'Error'() {
+			const collector = new ClientErrorCollector(mockRemote);
+			resultString = '[{"message":"Ooops...","source":"somefile.js","lineno":10,"colno":10,"error":{"message":"Ooops...","name":"Error","stack":""}}]';
+			lastResult = undefined;
+			collector.init()
+				.then(() => {
+					assert.throws(() => {
+						collector.assertNoErrors();
+					}, Error);
+				});
+		},
+
+		'EvalError'() {
+			const collector = new ClientErrorCollector(mockRemote);
+			resultString = '[{"message":"Ooops...","source":"somefile.js","lineno":10,"colno":10,"error":{"message":"Ooops...","name":"EvalError","stack":""}}]';
+			lastResult = undefined;
+			collector.init()
+				.then(() => {
+					assert.throws(() => {
+						collector.assertNoErrors();
+					}, EvalError);
+				});
+		},
+
+		'RangeError'() {
+			const collector = new ClientErrorCollector(mockRemote);
+			resultString = '[{"message":"Ooops...","source":"somefile.js","lineno":10,"colno":10,"error":{"message":"Ooops...","name":"RangeError","stack":""}}]';
+			lastResult = undefined;
+			collector.init()
+				.then(() => {
+					assert.throws(() => {
+						collector.assertNoErrors();
+					}, RangeError);
+				});
+		},
+
+		'ReferenceError'() {
+			const collector = new ClientErrorCollector(mockRemote);
+			resultString = '[{"message":"Ooops...","source":"somefile.js","lineno":10,"colno":10,"error":{"message":"Ooops...","name":"ReferenceError","stack":""}}]';
+			lastResult = undefined;
+			collector.init()
+				.then(() => {
+					assert.throws(() => {
+						collector.assertNoErrors();
+					}, ReferenceError);
+				});
+		},
+
+		'SyntaxError'() {
+			const collector = new ClientErrorCollector(mockRemote);
+			resultString = '[{"message":"Ooops...","source":"somefile.js","lineno":10,"colno":10,"error":{"message":"Ooops...","name":"SyntaxError","stack":""}}]';
+			lastResult = undefined;
+			collector.init()
+				.then(() => {
+					assert.throws(() => {
+						collector.assertNoErrors();
+					}, SyntaxError);
+				});
+		},
+
+		'TypeError'() {
+			const collector = new ClientErrorCollector(mockRemote);
+			resultString = '[{"message":"Ooops...","source":"somefile.js","lineno":10,"colno":10,"error":{"message":"Ooops...","name":"TypeError","stack":""}}]';
+			lastResult = undefined;
+			collector.init()
+				.then(() => {
+					assert.throws(() => {
+						collector.assertNoErrors();
+					}, TypeError);
+				});
+		},
+
+		'no error object'() {
+			const collector = new ClientErrorCollector(mockRemote);
+			resultString = '[{"message":"Ooops...","source":"somefile.js","lineno":10,"colno":10}]';
+			lastResult = undefined;
+			collector.init()
+				.then(() => {
+					assert.throws(() => {
+						collector.assertNoErrors();
+					}, Error);
+				});
+		}
+	}
+});

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -1,1 +1,2 @@
+import './ClientErrorCollector';
 import './main';


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

It initial commit to this repo uses `window.onerror` for the `ClientErrorCollector`.  The challenge with this is that the signature of the calls to `onerror` are not consistent across the platforms, meaning that sometimes error and stack information were not available, when they could be ascertained from the `error` event that is also emitted.

This PR changes to use an event listener which is slightly more consistent, though iOS 9 does not provide the actual error object 😭.  This causes the message of the reported error to be slightly different than the rest of the platforms.
