### PR TITLE
Allow target to be mocked in sendEvent

### DIFF
--- a/src/support/sendEvent.ts
+++ b/src/support/sendEvent.ts
@@ -138,7 +138,7 @@ export default function sendEvent<I extends EventInit>(target: Element, type: st
 				value: (<any> initProps).target,
 				writable: false,
 				enumerable: true,
-				configurable: true
+				configurable: false
 			});
 		}
 		deepAssign(event, initProps);

--- a/src/support/sendEvent.ts
+++ b/src/support/sendEvent.ts
@@ -133,6 +133,14 @@ export default function sendEvent<I extends EventInit>(target: Element, type: st
 		(event as CustomEvent).initCustomEvent(type, bubbles!, cancelable!, {});
 	}
 	try {
+		if ('target' in initProps) {
+			Object.defineProperty(event, 'target', {
+				value: (<any> initProps).target,
+				writable: false,
+				enumerable: true,
+				configurable: true
+			});
+		}
 		deepAssign(event, initProps);
 	}
 	catch (e) { /* swallowing assignment errors when trying to overwrite native event properties */ }

--- a/tests/unit/support/sendEvent.ts
+++ b/tests/unit/support/sendEvent.ts
@@ -57,6 +57,30 @@ registerSuite({
 		});
 	},
 
+	'mock target'() {
+		const target = document.createElement('div');
+		document.body.appendChild(target);
+
+		const mockTarget = {} as HTMLDivElement;
+		let called = false;
+
+		function listener(evt: CustomEvent) {
+			assert.strictEqual(evt.target, mockTarget, 'Target of event should be mock target');
+			called = true;
+		}
+
+		target.addEventListener('click', listener);
+
+		sendEvent(target, 'click', {
+			eventInit: {
+				target: mockTarget
+			}
+		});
+		assert.isTrue(called, 'listener should have been called');
+
+		document.body.removeChild(target);
+	},
+
 	'MouseEvents'() {
 		const target = document.createElement('button');
 		document.body.appendChild(target);


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [X] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [X] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

This PR adds the ability to supply `target` as part of the `eventInit` of `sendEvent` for use cases where there is a need for a _mock_ of the `target` when dispatching an event on the _real_ target.

Resolves #12 
