### PR TITLE
Improvements to loadJsdom

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "maquette": "2.4.3"
   },
   "dependencies": {
-    "jsdom": "^9.12.0",
+    "jsdom": "^10.0.0",
     "pepjs": "^0.4.2"
   },
   "devDependencies": {

--- a/src/support/loadJsdom.ts
+++ b/src/support/loadJsdom.ts
@@ -24,22 +24,26 @@ if (!('document' in global)) {
 	const jsdom = require('jsdom'); /* Only attempt to load JSDOM to avoid using a loader plugin */
 
 	/* create a virtual console and direct it to the global `console` */
-	virtualConsole = jsdom.createVirtualConsole() as VirtualConsole;
+	virtualConsole = new jsdom.VirtualConsole() as VirtualConsole;
 	virtualConsole.sendTo(console);
 
-	/* Create a new document and assign it to the global namespace */
-	doc = global.document = jsdom.jsdom(`
+	/* Create a new jsdom instance */
+	const dom = new jsdom.JSDOM(`
 		<!DOCTYPE html>
 		<html>
 		<head></head>
 		<body></body>
 		<html>
 	`, {
-		virtualConsole
+		virtualConsole,
+		runScripts: 'dangerously'
 	});
 
 	/* Assign a global window */
-	global.window = global.document.defaultView;
+	global.window = dom.window;
+
+	/* Assign a global document */
+	doc = global.document = global.window.document;
 
 	/* Assign a global DocParser */
 	global.DOMParser = global.window.DOMParser;

--- a/src/support/loadJsdom.ts
+++ b/src/support/loadJsdom.ts
@@ -67,6 +67,7 @@ if (!('document' in global)) {
 }
 else {
 	doc = document;
+	/* istanbul ignore else */
 	if (!exists('jsdom')) {
 		hasAdd('jsdom', false);
 	}

--- a/src/support/loadJsdom.ts
+++ b/src/support/loadJsdom.ts
@@ -1,4 +1,6 @@
 import global from '@dojo/core/global';
+import { add as hasAdd, exists } from '@dojo/has/has';
+import { VirtualConsole } from 'jsdom';
 
 /* In order to have the tests work under Node.js, we need to load JSDom and polyfill
  * requestAnimationFrame */
@@ -10,31 +12,40 @@ declare global {
 	}
 }
 
+/**
+ * If `jsdom` loads, this is a reference to the virtual console for the global `window` and `document`
+ */
+export let virtualConsole: VirtualConsole | undefined;
+
 /* Create a basic document */
 let doc: Document;
 
 if (!('document' in global)) {
 	const jsdom = require('jsdom'); /* Only attempt to load JSDOM to avoid using a loader plugin */
 
-	doc = jsdom.jsdom(`
+	/* create a virtual console and direct it to the global `console` */
+	virtualConsole = jsdom.createVirtualConsole() as VirtualConsole;
+	virtualConsole.sendTo(console);
+
+	/* Create a new document and assign it to the global namespace */
+	doc = global.document = jsdom.jsdom(`
 		<!DOCTYPE html>
 		<html>
 		<head></head>
 		<body></body>
 		<html>
 	`, {
-		/* direct the console of the document to the NodeJS console */
-		virtualConsole: jsdom.createVirtualConsole().sendTo(console)
+		virtualConsole
 	});
 
-	/* Assign it to the global namespace */
-	global.document = doc;
+	/* Assign a global window */
+	global.window = global.document.defaultView;
 
-	/* Assign a global window as well */
-	global.window = doc.defaultView;
+	/* Assign a global DocParser */
+	global.DOMParser = global.window.DOMParser;
 
 	/* Needed for Pointer Event Polyfill's incorrect Element detection */
-	global.Element = function() {};
+	global.Element = global.window.Element;
 
 	/* Patch feature detection of CSS Animations */
 	Object.defineProperty(
@@ -51,9 +62,14 @@ if (!('document' in global)) {
 	};
 
 	global.cancelAnimationFrame = () => {};
+
+	hasAdd('jsdom', true);
 }
 else {
 	doc = document;
+	if (!exists('jsdom')) {
+		hasAdd('jsdom', false);
+	}
 }
 
 export default doc;

--- a/tests/unit/harness.ts
+++ b/tests/unit/harness.ts
@@ -66,7 +66,7 @@ registerSuite({
 			widget.destroy();
 		},
 
-		'support custom event listners on rendering'() {
+		'support custom event listeners on rendering'() {
 			let called = false;
 
 			class CustomEventWidget extends WidgetBase<WidgetProperties> {
@@ -105,9 +105,9 @@ registerSuite({
 
 			const widget = harness(MisboundWidget);
 			widget.sendEvent('click');
-			assert.isTrue(clickCalled, 'event listner should have been called');
+			assert.isTrue(clickCalled, '"click" event listener should have been called');
 			widget.sendEvent('foo');
-			assert.isTrue(fooCalled, 'event listner should have been called');
+			assert.isTrue(fooCalled, '"foo" event listener should have been called');
 			widget.destroy();
 		},
 
@@ -391,7 +391,7 @@ registerSuite({
 	},
 
 	'.listener': {
-		'listner stub is present and returns true'() {
+		'listener stub is present and returns true'() {
 			const widget = harness(MockWidget);
 			assert.isFunction(widget.listener, 'listener should be a function');
 			assert.isTrue(widget.listener(), 'listener should return `true`');

--- a/tests/unit/support/loadJsdom.ts
+++ b/tests/unit/support/loadJsdom.ts
@@ -25,6 +25,14 @@ registerSuite({
 		assert.strictEqual(global.window, window, 'global window should equal window');
 	},
 
+	'global.Element is defined'() {
+		assert(global.Element, 'there should be a globally defined Element');
+	},
+
+	'global.DOMParser is defined'() {
+		assert(global.DOMParser, 'there should be a globally defined DOMParser');
+	},
+
 	'window has a reference to itself'(this: any) {
 		assert.strictEqual(window, window.window, 'window should have a reference to itself');
 	},
@@ -51,5 +59,9 @@ registerSuite({
 			this.skip('Not a NodeJS Environment');
 		}
 		assert.isFunction(cancelAnimationFrame);
+	},
+
+	'has flag is set properly'() {
+		assert[has('host-node') ? 'isTrue' : 'isFalse'](has('jsdom'), 'should have proper flag set for "jsdom"');
 	}
 });


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [X] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [X] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

This PR improves `loadJsdom` by providing a `has('jsdom')` as well as making the `DOMParser` globally available and using the `window.Element` as a fill for the global `Element` instead of just a stub function.

~~I tried to upgrade to jsdom v10, but [this issue](https://github.com/tmpvar/jsdom/issues/1828) is a blocker.~~

It also upgrades to jsdom v10, which is the currently supported version.

Resolves #27
