### PR TITLE
Add ability to easily mock loader modules

### DIFF
--- a/src/loader/loadModule.ts
+++ b/src/loader/loadModule.ts
@@ -1,0 +1,26 @@
+/**
+ * An async function which attempts to load the `mid` and resolve to the contents of the module.  If there is an error,
+ * the function will reject with the error.
+ *
+ * By default, the function will attempt to undefine the module before loading it.  This can be skipped via `noUndef`.
+ *
+ * A local reference to `require` can be passed to change the location of relative module IDs.
+ * @param mid The mid to load
+ * @param req A local require for relative mids
+ * @param noUndef Skip undefining a module
+ */
+export default async function loadModule(mid: string, req: NodeRequire = require, noUndef: boolean = false): Promise<any> {
+	if (!noUndef) {
+		req.undef(req.toAbsMid(mid));
+	}
+	return new Promise((resolve, reject) => {
+		const handle = req.on('error', (e: Error) => {
+			handle.remove();
+			reject(e);
+		});
+		req([ mid ], (result) => {
+			handle.remove();
+			resolve(result);
+		});
+	});
+}

--- a/src/loader/mock.ts
+++ b/src/loader/mock.ts
@@ -1,0 +1,82 @@
+/// <reference path="../../node_modules/@dojo/loader/dojo-loader.d.ts" />
+
+import { createHandle } from '@dojo/core/lang';
+import { Handle } from '@dojo/interfaces/core';
+import { forOf } from '@dojo/shim/iterator';
+import Map from '@dojo/shim/Map';
+
+declare const define: DojoLoader.Define;
+
+const moduleMap = new Map<string, () => void>();
+
+let disableHandle: Handle | undefined;
+
+/* TODO: remove when https://github.com/dojo/loader/issues/126 is resolved */
+declare global {
+	interface NodeRequire {
+		undef(moduleId: string, recursive?: boolean): void;
+	}
+}
+
+/**
+ * Register a module to be mocked when mocking is enabled
+ * @param mid The absolute module ID to mock
+ * @param mock The mock definition of the module
+ */
+export function register(mid: string, mock: any, req: NodeRequire = require): Handle {
+	if (disableHandle) {
+		throw new Error('Cannot register modules while mock is enabled.');
+	}
+	const absoluteMid = req.toAbsMid(mid);
+	moduleMap.set(absoluteMid, () => define(absoluteMid, [], () => mock));
+	return createHandle(() => {
+		if (disableHandle) {
+			req.undef(absoluteMid);
+			require.cache({
+				[mid]: undefined
+			});
+
+			/* TODO: remove when https://github.com/dojo/loader/issues/124 resolved */
+			require.cache({});
+		}
+		moduleMap.delete(absoluteMid);
+	});
+}
+
+/**
+ * Enable mocking of modules with the `@dojo/loader`.
+ *
+ * The function will return a `Handle` which will disable the mocks and remove them from
+ * the loader.
+ */
+export function enable(): Handle {
+	if (disableHandle) {
+		return disableHandle;
+	}
+
+	const map: { [mid: string]: () => void } = Object.create(null);
+	forOf(moduleMap, ([ mid, value ]) => {
+		require.undef(mid);
+		map[mid] = value;
+	});
+	require.cache(map);
+
+	/* TODO: remove when https://github.com/dojo/loader/issues/124 resolved */
+	require.cache({});
+
+	return disableHandle = createHandle(() => {
+		const emptyMap: { [mid: string]: undefined } = {};
+		forOf(moduleMap, ([ mid ]) => {
+			require.undef(mid);
+			emptyMap[mid] = undefined;
+		});
+		moduleMap.clear();
+
+		require.cache(emptyMap);
+
+		/* TODO: remove when https://github.com/dojo/loader/issues/124 resolved */
+		require.cache({});
+
+		disableHandle = undefined;
+	});
+}

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -64,7 +64,7 @@ export const loaderOptions = {
 };
 
 // Non-functional test suite(s) to run in each browser
-export const suites = [ 'tests/unit/all' ];
+export const suites = [ 'src/support/loadJsdom', 'tests/unit/all' ];
 
 // Functional test suite(s) to run in each browser once non-functional tests are completed
 export const functionalSuites = [ 'tests/functional/all' ];

--- a/tests/support/dependencyA.ts
+++ b/tests/support/dependencyA.ts
@@ -1,0 +1,3 @@
+export { baz } from './dependencyC';
+export let foo = 'bar';
+export let bar = 2;

--- a/tests/support/dependencyB.ts
+++ b/tests/support/dependencyB.ts
@@ -1,0 +1,3 @@
+export default function foo(): string {
+	return 'bar';
+};

--- a/tests/support/dependencyC.ts
+++ b/tests/support/dependencyC.ts
@@ -1,0 +1,1 @@
+export const baz = {};

--- a/tests/support/example.ts
+++ b/tests/support/example.ts
@@ -1,0 +1,6 @@
+export { foo, bar, baz } from './dependencyA';
+import functionFoo from './dependencyB';
+
+export let qat = 'foo';
+
+export default functionFoo;

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -1,8 +1,5 @@
-/* Ensure there is a DOM to test against */
-import '../../src/support/loadJsdom';
-
-/* Modules to test */
 import './harness';
 import './main';
 import './intern/all';
+import './loader/all';
 import './support/all';

--- a/tests/unit/loader/all.ts
+++ b/tests/unit/loader/all.ts
@@ -1,0 +1,2 @@
+import './loadModule';
+import './mock';

--- a/tests/unit/loader/loadModule.ts
+++ b/tests/unit/loader/loadModule.ts
@@ -1,0 +1,52 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+import loadModule from '../../../src/loader/loadModule';
+import * as Module from '../../support/example';
+
+registerSuite({
+	name: 'loader/loadModule',
+
+	async 'loads module and dependencies'() {
+		const example: typeof Module = await loadModule('../../tests/support/example');
+		assert.isFunction(example.default);
+		assert.isString(example.foo);
+		assert.isNumber(example.bar);
+		assert.deepEqual(example.baz, {});
+		assert.strictEqual(example.qat, 'foo');
+	},
+
+	async 'uses relative require'() {
+		const example: typeof Module = await loadModule('../../support/example', require);
+		assert.isFunction(example.default);
+		assert.isString(example.foo);
+		assert.isNumber(example.bar);
+		assert.deepEqual(example.baz, {});
+		assert.strictEqual(example.qat, 'foo');
+	},
+
+	async 'does undefine before require'() {
+		let example: typeof Module = await loadModule('../../tests/support/example');
+		example.qat = 'bar';
+		assert.strictEqual(example.qat, 'bar', 'should equal changed value');
+		example = await loadModule('../../tests/support/example');
+		assert.strictEqual(example.qat, 'foo', 'should equal orginal value');
+	},
+
+	async 'respects noundef before require'() {
+		let example: typeof Module = await loadModule('../../tests/support/example');
+		example.qat = 'bar';
+		assert.strictEqual(example.qat, 'bar', 'should equal changed value');
+		example = await loadModule('../../support/example', require, true);
+		assert.strictEqual(example.qat, 'bar', 'still have old value');
+	},
+
+	'rejects on missing module'(this: any) {
+		const dfd = this.async();
+		loadModule('../../tests/support/missing')
+			.then(() => {
+					throw new Error('Should reject');
+				}, dfd.callback((e: Error) => {
+					assert.instanceOf(e, Error, 'should be instance of error');
+				}));
+	}
+});

--- a/tests/unit/loader/mock.ts
+++ b/tests/unit/loader/mock.ts
@@ -1,0 +1,114 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+import { enable, register } from '../../../src/loader/mock';
+import loadModule from '../../../src/loader/loadModule';
+import * as Example from '../../support/example';
+import * as DependencyA from '../../support/dependencyA';
+
+registerSuite({
+	name: 'loader/mock',
+
+	async 'module subtitution'() {
+		register('foo/bar/baz', {
+			foo: 'foo'
+		});
+		const enableHandle = enable();
+		const result = await loadModule('foo/bar/baz');
+		assert.deepEqual(result, {
+			foo: 'foo'
+		});
+		enableHandle.destroy();
+	},
+
+	async 'relative module subtitution'() {
+		register('./foo/bar/baz', {
+			foo: 'foo'
+		});
+		const enableHandle = enable();
+		const result = await loadModule('./foo/bar/baz');
+		assert.deepEqual(result, {
+			foo: 'foo'
+		});
+		enableHandle.destroy();
+	},
+
+	async 'relative module to abs mid'() {
+		register('./foo/bar/baz', {
+			foo: 'foo'
+		}, require);
+		const enableHandle = enable();
+		const mid = require.toAbsMid('./foo/bar/baz');
+		const result = await loadModule(mid);
+		assert.deepEqual(result, {
+			foo: 'foo'
+		});
+		enableHandle.destroy();
+	},
+
+	async 'subtitution of dependencies'() {
+		register(require.toAbsMid('../../support/dependencyA'), {
+			baz: { foo: 'bar' },
+			foo: 'qat',
+			bar: 99
+		} as typeof DependencyA);
+		const enableHandle = enable();
+		const result: typeof Example = await loadModule('../../support/example', require);
+		assert.strictEqual(result.foo, 'qat', 'should have value from mocked module');
+		assert.strictEqual(result.bar, 99, 'should have value from mocked module');
+		assert.deepEqual(result.baz, { foo: 'bar' }, 'should have value from mocked module');
+		assert.strictEqual(result.qat, 'foo', 'should have required dependency');
+		assert.isFunction(result.default);
+		enableHandle.destroy();
+	},
+
+	async 'removal of registered module before enablement'() {
+		const handle = register(require.toAbsMid('../../support/dependencyA'), {
+			baz: { foo: 'bar' },
+			foo: 'qat',
+			bar: 99
+		} as typeof DependencyA);
+		handle.destroy();
+		const enableHandle = enable();
+		const result: typeof Example = await loadModule('../../support/example', require);
+		assert.strictEqual(result.foo, 'bar', 'should have value from mocked module');
+		assert.strictEqual(result.bar, 2, 'should have value from mocked module');
+		assert.deepEqual(result.baz, { }, 'should have value from mocked module');
+		enableHandle.destroy();
+	},
+
+	async 'removal of registered module after enablement'() {
+		const handle = register(require.toAbsMid('../../support/dependencyA'), {
+			baz: { foo: 'bar' },
+			foo: 'qat',
+			bar: 99
+		} as typeof DependencyA);
+		const enableHandle = enable();
+		handle.destroy();
+		const result: typeof Example = await loadModule('../../support/example', require);
+		assert.strictEqual(result.foo, 'bar', 'should have value from mocked module');
+		assert.strictEqual(result.bar, 2, 'should have value from mocked module');
+		assert.deepEqual(result.baz, { }, 'should have value from mocked module');
+		enableHandle.destroy();
+	},
+
+	'already enabled return same handle'() {
+		const handle1 = enable();
+		const handle2 = enable();
+		assert.strictEqual(handle1, handle2, 'should be the same handle');
+		handle1.destroy();
+		assert.notStrictEqual(handle1, enable(), 'should re-enable');
+	},
+
+	'duplicate calls to handles do not cause issues'() {
+		const handle = enable();
+		handle.destroy();
+		handle.destroy();
+	},
+
+	'registering mocks after enablement throws'() {
+		enable();
+		assert.throws(() => {
+			register('foo, bar, baz', {});
+		}, Error, 'Cannot register modules while mock is enabled.');
+	}
+});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [X] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

This PR provides the ability to easily mock (and dynamically load) modules when using the `@dojo/loader` as the module loader.

The README contains updates describing the new functionality.

Resolves #25 
