### PR TITLE
Remove unnecessary logic for children from assertRender

### DIFF
--- a/src/support/assertRender.ts
+++ b/src/support/assertRender.ts
@@ -75,10 +75,19 @@ export default function assertRender(actual: DNode, expected: DNode, options?: A
 		});
 	}
 
-	if (localIsHNode(actual) && localIsHNode(expected)) {
-		if (actual.tag !== expected.tag) {
-			/* The tags do not match */
-			throwAssertionError(actual.tag, expected.tag, message);
+	if ((localIsHNode(actual) && localIsHNode(expected)) || (localIsWNode(actual) && localIsWNode(expected))) {
+		if (localIsHNode(actual) && localIsHNode(expected)) {
+			if (actual.tag !== expected.tag) {
+				/* The tags do not match */
+				throwAssertionError(actual.tag, expected.tag, message);
+			}
+		}
+		/* istanbul ignore else: not being tracked by TypeScript properly */
+		else if (localIsWNode(actual) && localIsWNode(expected)) {
+			if (actual.widgetConstructor !== expected.widgetConstructor) {
+				/* The WNode does not share the same constructor */
+				throwAssertionError(actual.widgetConstructor, expected.widgetConstructor, message);
+			}
 		}
 		const delta = diff(actual.properties, expected.properties, diffOptions);
 		if (delta.length) {
@@ -87,25 +96,6 @@ export default function assertRender(actual: DNode, expected: DNode, options?: A
 		}
 		/* We need to assert the children match */
 		assertChildren(actual.children, expected.children);
-	}
-	else if (localIsWNode(actual) && localIsWNode(expected)) {
-		if (actual.widgetConstructor !== expected.widgetConstructor) {
-			/* The WNode does not share the same constructor */
-			throwAssertionError(actual.widgetConstructor, expected.widgetConstructor, message);
-		}
-		const delta = diff(actual.properties, expected.properties, diffOptions);
-		if (delta.length) {
-			/* There are differences in the properties between the two nodes */
-			throwAssertionError(actual.properties, expected.properties, message);
-		}
-		if (actual.children && expected.children) {
-			/* We need to assert the children match */
-			assertChildren(actual.children, expected.children);
-		}
-		else if (actual.children || expected.children) {
-			/* One WNode has children, but the other doesn't */
-			throwAssertionError(actual.children, expected.children, message);
-		}
 	}
 	else if (typeof actual === 'string' && typeof expected === 'string') {
 		/* Both DNodes are strings */


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [X] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [X] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

This PR removes unnecessary code that was guarding against the possibility that on `WNode`s there might not be a children array.  An upstream change in `widget-core` removed the need to guard against this, causing certain code paths to not be covered.

Resolves #15 
