### PR TITLE
Allow custom comparisons of property values

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ special virtual DOM nodes before being sent to the virtual DOM engine for render
 like `<test--widget-stub data--widget-name="<<widget class name>>"></test--widget-stub>`, where `data--widget-name` will be set
 to either the widget class tag or the name of the class (*note* IE11 does not support function names, therefore it will have
 `<Anonymous>` as the value of the attribute instead.  The substituion occurs *after* the virtual DOM is compared on an
-`.expectedRender()` assertion, so expected virtual DOM passed to that function should be as the widget will be expected to
+`.expectRender()` assertion, so expected virtual DOM passed to that function should be as the widget will be expected to
 return from its `.render()` implimentation.
 
 Basic usage of `harness()` would look like this:
@@ -187,7 +187,7 @@ widget.expectRender(expected);
 Cleans up the `harness` instance and removes the harness and other rendered DOM from the DOM.  You should *always* call `.destroy()`
 otherwise you will leave quite a lot of grabage DOM in the document which may have impacts on other tests you will run.
 
-#### .expectedRender()
+#### .expectRender()
 
 Provide an expected of virtual DOM which will be compared with the actual rendered virtual DOM from the widget class.  It *spies*
 the result from the harnessed widget's `.render()` return and compares that with the provided expected virtual DOM.  If the `actual`

--- a/README.md
+++ b/README.md
@@ -456,6 +456,34 @@ assignProperties(expected, {
 });
 ```
 
+### compareProperty()
+
+Returns an object which is used in render assertion comparisons like `harness.expectRender()` or `assertRender()`.  This is designed
+to allow validation of propery values that are difficult to know or obtain references to until the widget has rendered (e.g. registries or dynamically generated IDs).
+
+The function takes a single argument of `callback` which is a function that will be called when the property value needs to be validated.
+This `callback` can take up to three arguments.  The first is the `value` of the property to check, the second is the `name` of the
+property, and `parent` is either the actual `WidgetProperties` or `VirtualDomProperties` that this value is from.  If the value is _valid_
+then the function should return `true`, if the value is _not valid_ returning `false` will cause an `AssertionError` to be thrown, naming
+the property which has an unexpected value.
+
+*Note:* the type of the return value can often not be valid for the property value that you are passing it for.  You may need to cast
+it as `any` in order to allow TypeScript type checking to succeed.
+
+An example of usage would be:
+
+```ts
+import { compareProperty } from '@dojo/test-extras/support/d';
+
+const compareRegistryProperty = compareProperty((value) => {
+    return value instanceof Registry;
+});
+
+widget.expectRender(v('div', {}, [
+    w('child', { registry: compareRegistryProperty })
+]));
+```
+
 ### findIndex()
 
 Returns a node identified by the supplied `index`.  The first argument is the _root_ virtual DOM node (`WNode` or `HNode`) and the

--- a/src/support/assertRender.ts
+++ b/src/support/assertRender.ts
@@ -75,10 +75,19 @@ export default function assertRender(actual: DNode, expected: DNode, options?: A
 		});
 	}
 
-	if (localIsHNode(actual) && localIsHNode(expected)) {
-		if (actual.tag !== expected.tag) {
-			/* The tags do not match */
-			throwAssertionError(actual.tag, expected.tag, message);
+	if ((localIsHNode(actual) && localIsHNode(expected)) || (localIsWNode(actual) && localIsWNode(expected))) {
+		if (localIsHNode(actual) && localIsHNode(expected)) {
+			if (actual.tag !== expected.tag) {
+				/* The tags do not match */
+				throwAssertionError(actual.tag, expected.tag, message);
+			}
+		}
+		/* istanbul ignore else: not being tracked by TypeScript properly */
+		else if (localIsWNode(actual) && localIsWNode(expected)) {
+			if (actual.widgetConstructor !== expected.widgetConstructor) {
+				/* The WNode does not share the same constructor */
+				throwAssertionError(actual.widgetConstructor, expected.widgetConstructor, message);
+			}
 		}
 		const delta = diff(actual.properties, expected.properties, diffOptions);
 		if (delta.length) {
@@ -87,25 +96,6 @@ export default function assertRender(actual: DNode, expected: DNode, options?: A
 		}
 		/* We need to assert the children match */
 		assertChildren(actual.children, expected.children);
-	}
-	else if (localIsWNode(actual) && localIsWNode(expected)) {
-		if (actual.widgetConstructor !== expected.widgetConstructor) {
-			/* The WNode does not share the same constructor */
-			throwAssertionError(actual.widgetConstructor, expected.widgetConstructor, message);
-		}
-		const delta = diff(actual.properties, expected.properties, diffOptions);
-		if (delta.length) {
-			/* There are differences in the properties between the two nodes */
-			throwAssertionError(actual.properties, expected.properties, message);
-		}
-		if (actual.children && expected.children) {
-			/* We need to assert the children match */
-			assertChildren(actual.children, expected.children);
-		}
-		else if (actual.children || expected.children) {
-			/* One WNode has children, but the other doesn't */
-			throwAssertionError(actual.children, expected.children, message);
-		}
 	}
 	else if (typeof actual === 'string' && typeof expected === 'string') {
 		/* Both DNodes are strings */

--- a/src/support/compare.ts
+++ b/src/support/compare.ts
@@ -54,7 +54,7 @@ export interface ConstructDescriptor {
  */
 export interface UnamedConstructRecord {
 	/**
-	 * Any arguments to pass the constructor function
+	 * Any arguments to pass to the constructor function
 	 */
 	args?: any[];
 
@@ -150,7 +150,7 @@ export interface SpliceRecord {
 /**
  * A record that describes how to instantiate a new object via a constructor function
  * @param Ctor The constructor function
- * @param args Any arguments to be passed the constructor function
+ * @param args Any arguments to be passed to the constructor function
  */
 /* tslint:disable:variable-name */
 export function createConstructRecord(Ctor: Constructor, args?: any[], descriptor?: ConstructDescriptor): UnamedConstructRecord {

--- a/src/support/compare.ts
+++ b/src/support/compare.ts
@@ -74,7 +74,7 @@ export interface UnamedConstructRecord {
 	propertyRecords?: (ConstructRecord | PatchRecord)[];
 }
 
-interface ConstructRecord extends UnamedConstructRecord {
+export interface ConstructRecord extends UnamedConstructRecord {
 	/**
 	 * The name of the property on the Object
 	 */

--- a/src/support/compare.ts
+++ b/src/support/compare.ts
@@ -35,6 +35,53 @@ export interface DiffOptions {
 }
 
 /**
+ * Interface for a generic constructor function
+ */
+export interface Constructor {
+	new (...args: any[]): object;
+	prototype: object;
+}
+
+export interface ConstructDescriptor {
+	configurable?: boolean;
+	enumerable?: boolean;
+	writable?: boolean;
+}
+
+/**
+ * A record that describes a constructor function and arguments necessary to create an instance of
+ * an object
+ */
+export interface UnamedConstructRecord {
+	/**
+	 * Any arguments to pass the constructor function
+	 */
+	args?: any[];
+
+	/**
+	 * The constructor function to use to create the instance
+	 */
+	Ctor: Constructor;
+
+	/**
+	 * The partial descriptor that is used to set the value of the instance
+	 */
+	descriptor?: ConstructDescriptor;
+
+	/**
+	 * Any patches to properties that need to occur on the instance
+	 */
+	propertyRecords?: (ConstructRecord | PatchRecord)[];
+}
+
+interface ConstructRecord extends UnamedConstructRecord {
+	/**
+	 * The name of the property on the Object
+	 */
+	name: string;
+}
+
+/**
  * A record that describes the mutations necessary to a property of an object to make that property look
  * like another
  */
@@ -67,7 +114,7 @@ export type PatchRecord = {
 		/**
 		 * Additional patch records which describe the value of the property
 		 */
-		valueRecords?: (PatchRecord | SpliceRecord)[];
+		valueRecords?: (ConstructRecord | PatchRecord | SpliceRecord)[];
 	};
 
 /**
@@ -101,6 +148,24 @@ export interface SpliceRecord {
 }
 
 /**
+ * A record that describes how to instantiate a new object via a constructor function
+ * @param Ctor The constructor function
+ * @param args Any arguments to be passed the constructor function
+ */
+/* tslint:disable:variable-name */
+export function createConstructRecord(Ctor: Constructor, args?: any[], descriptor?: ConstructDescriptor): UnamedConstructRecord {
+	const record: UnamedConstructRecord = assign(objectCreate(null), { Ctor });
+	if (args) {
+		record.args = args;
+	}
+	if (descriptor) {
+		record.descriptor = descriptor;
+	}
+	return record;
+}
+/* tslint:enable:variable-name */
+
+/**
  * An internal function that returns a new patch record
  *
  * @param type The type of patch record
@@ -108,7 +173,7 @@ export interface SpliceRecord {
  * @param descriptor The property descriptor to be installed on the object
  * @param valueRecords Any subsequenet patch recrds to be applied to the value of the descriptor
  */
-function createPatchRecord(type: PatchTypes, name: string, descriptor?: PropertyDescriptor, valueRecords?: (PatchRecord | SpliceRecord)[]): PatchRecord {
+function createPatchRecord(type: PatchTypes, name: string, descriptor?: PropertyDescriptor, valueRecords?: (ConstructRecord | PatchRecord | SpliceRecord)[]): PatchRecord {
 	const patchRecord = assign(objectCreate(null), {
 		type,
 		name
@@ -267,9 +332,9 @@ function diffArray(a: any[], b: any, options: DiffOptions): SpliceRecord[] {
  * @param b The second plain bject to compare to
  * @param options An options bag that allows configuration of the behaviour of `diffPlainObject()`
  */
-function diffPlainObject(a: any, b: any, options: DiffOptions): PatchRecord[] {
+function diffPlainObject(a: any, b: any, options: DiffOptions): (ConstructRecord | PatchRecord)[] {
 	const { allowFunctionValues = false, ignoreProperties = [], ignorePropertyValues = [] } = options;
-	const patchRecords: PatchRecord[] = [];
+	const patchRecords: (ConstructRecord | PatchRecord)[] = [];
 
 	function isIgnoredProperty(name: string) {
 		return Array.isArray(ignoreProperties) ? ignoreProperties.some((value) => {
@@ -302,7 +367,7 @@ function diffPlainObject(a: any, b: any, options: DiffOptions): PatchRecord[] {
 			const isValueAArray = isArray(valueA);
 			const isValueAPlainObject = isPlainObject(valueA);
 
-			if ((isValueAArray || isValueAPlainObject) && !(isIgnoredPropertyValue(name))) { /* non-primitive values we can diff */
+			if ((isValueAArray || isValueAPlainObject) && !isIgnoredPropertyValue(name)) { /* non-primitive values we can diff */
 				/* this is a bit complicated, but essentially if valueA and valueB are both arrays or plain objects, then
 				* we can diff those two values, if not, then we need to use an empty array or an empty object and diff
 				* the valueA with that */
@@ -312,6 +377,18 @@ function diffPlainObject(a: any, b: any, options: DiffOptions): PatchRecord[] {
 				const valueRecords = diff(valueA, value, options);
 				if (valueRecords.length) { /* only add if there are changes */
 					patchRecords.push(createPatchRecord(type, name, createValuePropertyDescriptor(value), diff(valueA, value, options)));
+				}
+			}
+			else if (isObjectDiff(valueA) && !isObjectDiff(valueB)) { /* complex diff left hand */
+				const result = valueA.diff(valueB, name, b);
+				if (result) {
+					patchRecords.push(result);
+				}
+			}
+			else if (isObjectDiff(valueB)) { /* complex diff right hand */
+				const result = valueB.diff(valueA, name, a);
+				if (result) {
+					patchRecords.push(result);
 				}
 			}
 			else if (isPrimitive(valueA) || (allowFunctionValues && typeof valueA === 'function') || isIgnoredPropertyValue(name)) {
@@ -334,6 +411,14 @@ function diffPlainObject(a: any, b: any, options: DiffOptions): PatchRecord[] {
 	}, patchRecords);
 
 	return patchRecords;
+}
+
+/**
+ * A guard that determines if the value is a `ConstructRecord`
+ * @param value The value to check
+ */
+function isConstructRecord(value: any): value is ConstructRecord {
+	return Boolean(value && typeof value === 'object' && value !== null && value.Ctor && value.name);
 }
 
 /**
@@ -381,6 +466,14 @@ function isPrimitive(value: any): value is (string | number | boolean | undefine
 		typeofValue === 'string' ||
 		typeofValue === 'number' ||
 		typeofValue === 'boolean';
+}
+
+/**
+ * A guard that determines if the value is a `ObjectDiff`
+ * @param value The value to check
+ */
+function isObjectDiff<T>(value: any): value is ObjectDiff<T> {
+	return typeof value === 'object' && value instanceof ObjectDiff;
 }
 
 /**
@@ -433,6 +526,22 @@ function patchPatch(target: any, record: PatchRecord): any {
 	return target;
 }
 
+const defaultConstructDescriptor = {
+	configurable: true,
+	enumerable: true,
+	writable: true
+};
+
+function patchConstruct(target: any, record: ConstructRecord): any {
+	const { args, descriptor = defaultConstructDescriptor, Ctor, name, propertyRecords } = record;
+	const value = new Ctor(...(args || []));
+	if (propertyRecords) {
+		propertyRecords.forEach((record) => isConstructRecord(record) ? patchConstruct(value, record) : patchPatch(value, record));
+	}
+	defineProperty(target, name, assign({ value }, descriptor));
+	return target;
+}
+
 /**
  * An internal function that take a value from array being patched and the target value from the same
  * index and determines the value that should actually be patched into the target array
@@ -450,6 +559,23 @@ function resolveTargetValue(patchValue: any, targetValue: any): any {
 		patchValue;
 }
 
+export type ObjectDiffFunction<T> = (value: T, nameOrIndex: string | number, parent: object) => UnamedConstructRecord | void;
+
+export class ObjectDiff<T extends object> {
+	private _differ: ObjectDiffFunction<T>;
+
+	constructor(diff: ObjectDiffFunction<T>) {
+		this._differ = diff;
+	}
+
+	diff(value: T, nameOrIndex: string | number, parent: object): ConstructRecord | void {
+		const record = this._differ(value, nameOrIndex, parent);
+		if (record && typeof nameOrIndex === 'string') {
+			return assign(record, { name: nameOrIndex });
+		}
+	}
+}
+
 /**
  * Compares to plain objects or arrays and return a set of records which describe the differences between the two
  *
@@ -459,7 +585,7 @@ function resolveTargetValue(patchValue: any, targetValue: any): any {
  * @param b The plain object or array to compare to
  * @param options An options bag that allows configuration of the behaviour of `diff()`
  */
-export function diff(a: any, b: any, options: DiffOptions = {}): (PatchRecord | SpliceRecord)[] {
+export function diff(a: any, b: any, options: DiffOptions = {}): (ConstructRecord | PatchRecord | SpliceRecord)[] {
 	if (typeof a !== 'object' || typeof b !== 'object') {
 		throw new TypeError('Arguments are not of type object.');
 	}
@@ -485,7 +611,7 @@ export function diff(a: any, b: any, options: DiffOptions = {}): (PatchRecord | 
  * @param target The plain object or array that the patch records should be applied to
  * @param records A set of patch records to be applied to the target
  */
-export function patch(target: any, records: (PatchRecord | SpliceRecord)[]): any {
+export function patch(target: any, records: (ConstructRecord | PatchRecord | SpliceRecord)[]): any {
 	if (!isArray(target) && !isPlainObject(target)) {
 		throw new TypeError('A target for a patch must be either an array or a plain object.');
 	}
@@ -494,10 +620,10 @@ export function patch(target: any, records: (PatchRecord | SpliceRecord)[]): any
 	}
 
 	records.forEach((record) => {
-		target = isSpliceRecord(record) ?
-			patchSplice(isArray(target) ?
-				target : [], record) : patchPatch(isPlainObject(target) ?
-					target : objectCreate(null), record);
+		target = isSpliceRecord(record)
+			? patchSplice(isArray(target) ? target : [], record) /* patch arrays */
+			: isConstructRecord(record) ? patchConstruct(target, record) /* patch complex object */
+				: patchPatch(isPlainObject(target) ? target : {}, record); /* patch plain object */
 	});
 	return target;
 }

--- a/src/support/compare.ts
+++ b/src/support/compare.ts
@@ -42,9 +42,26 @@ export interface Constructor {
 	prototype: object;
 }
 
+/**
+ * A partial property descriptor that provides the property descriptor flags supported by the
+ * complex property construction of `patch()`
+ *
+ * All properties are value properties, with the value being supplied by the `ConstructRecord`
+ */
 export interface ConstructDescriptor {
+	/**
+	 * Is the property configurable?
+	 */
 	configurable?: boolean;
+
+	/**
+	 * Is the property enumerable?
+	 */
 	enumerable?: boolean;
+
+	/**
+	 * Is the property configurable?
+	 */
 	writable?: boolean;
 }
 
@@ -52,7 +69,7 @@ export interface ConstructDescriptor {
  * A record that describes a constructor function and arguments necessary to create an instance of
  * an object
  */
-export interface UnamedConstructRecord {
+export interface AnonymousConstructRecord {
 	/**
 	 * Any arguments to pass to the constructor function
 	 */
@@ -74,7 +91,7 @@ export interface UnamedConstructRecord {
 	propertyRecords?: (ConstructRecord | PatchRecord)[];
 }
 
-export interface ConstructRecord extends UnamedConstructRecord {
+export interface ConstructRecord extends AnonymousConstructRecord {
 	/**
 	 * The name of the property on the Object
 	 */
@@ -153,8 +170,8 @@ export interface SpliceRecord {
  * @param args Any arguments to be passed to the constructor function
  */
 /* tslint:disable:variable-name */
-export function createConstructRecord(Ctor: Constructor, args?: any[], descriptor?: ConstructDescriptor): UnamedConstructRecord {
-	const record: UnamedConstructRecord = assign(objectCreate(null), { Ctor });
+export function createConstructRecord(Ctor: Constructor, args?: any[], descriptor?: ConstructDescriptor): AnonymousConstructRecord {
+	const record: AnonymousConstructRecord = assign(objectCreate(null), { Ctor });
 	if (args) {
 		record.args = args;
 	}
@@ -231,7 +248,7 @@ function createValuePropertyDescriptor(value: any, writable: boolean = true, enu
 /**
  * A function that returns a constructor record or `undefined` when diffing a value
  */
-export type CustomDiffFunction<T> = (value: T, nameOrIndex: string | number, parent: object) => UnamedConstructRecord | void;
+export type CustomDiffFunction<T> = (value: T, nameOrIndex: string | number, parent: object) => AnonymousConstructRecord | void;
 
 /**
  * A class which is used when making a custom comparison of a non-plain object or array

--- a/src/support/d.ts
+++ b/src/support/d.ts
@@ -1,6 +1,8 @@
 import { assign } from '@dojo/core/lang';
 import { DNode, HNode, VirtualDomProperties, WidgetProperties, WNode } from '@dojo/widget-core/interfaces';
 import { isHNode, isWNode } from '@dojo/widget-core/d';
+import AssertionError from './AssertionError';
+import { CustomDiff } from './compare';
 
 export function assignChildProperties(target: WNode | HNode, index: number | string, properties: WidgetProperties | VirtualDomProperties): WNode | HNode {
 	const node = findIndex(target, index);
@@ -17,6 +19,20 @@ export function assignProperties(target: WNode | HNode, properties: WidgetProper
 export function assignProperties(target: WNode | HNode, properties: WidgetProperties | VirtualDomProperties): WNode | HNode {
 	assign(target.properties, properties);
 	return target;
+}
+
+/**
+ * Creates a function which when placed in an expected render will call the `callback`.  If the `callback` returns `true`, the value
+ * of the property is considered equal, otherwise it is considerd not equal and expected render will fail.
+ * @param callback A function that is invoked when comparing the property value
+ */
+export function compareProperty<T>(callback: (value: T, name: string, parent: WidgetProperties | VirtualDomProperties) => boolean): CustomDiff<T> {
+	function differ(value: T, name: string, parent: WidgetProperties | VirtualDomProperties) {
+		if (!callback(value, name, parent)) {
+			throw new AssertionError(`The value of property "${name}" is unexpected.`, {}, differ);
+		}
+	}
+	return new CustomDiff(differ);
 }
 
 /**

--- a/src/support/d.ts
+++ b/src/support/d.ts
@@ -22,8 +22,8 @@ export function assignProperties(target: WNode | HNode, properties: WidgetProper
 }
 
 /**
- * Creates a function which when placed in an expected render will call the `callback`.  If the `callback` returns `true`, the value
- * of the property is considered equal, otherwise it is considerd not equal and expected render will fail.
+ * Creates a function which, when placed in an expected render, will call the `callback`.  If the `callback` returns `true`, the value
+ * of the property is considered equal, otherwise it is considerd not equal and the expected render will fail.
  * @param callback A function that is invoked when comparing the property value
  */
 export function compareProperty<T>(callback: (value: T, name: string, parent: WidgetProperties | VirtualDomProperties) => boolean): CustomDiff<T> {

--- a/tests/unit/harness.ts
+++ b/tests/unit/harness.ts
@@ -1,10 +1,12 @@
 import * as assert from 'intern/chai!assert';
 import * as registerSuite from 'intern!object';
 import harness from '../../src/harness';
+import { compareProperty } from '../../src/support/d';
 
 import { v, w } from '@dojo/widget-core/d';
 import { WidgetProperties } from '@dojo/widget-core/interfaces';
 import WidgetBase from '@dojo/widget-core/WidgetBase';
+import AssertionError from '../../src/support/AssertionError';
 import assertRender from '../../src/support/assertRender';
 
 const hasFunctionName = (() => {
@@ -21,6 +23,34 @@ interface MockWidgetProperties extends WidgetProperties {
 class MockWidget<P extends MockWidgetProperties> extends WidgetBase<P> {
 	render() {
 		return v('div.foo');
+	}
+}
+
+class MockRegistry {
+	tag: string;
+}
+
+interface RegistryWidgetProperties extends WidgetProperties {
+	registry: MockRegistry;
+}
+
+class RegistryWidgetChild extends WidgetBase<RegistryWidgetProperties> {
+	render() {
+		return v('span');
+	}
+}
+
+class RegisterChildWidget extends WidgetBase<WidgetProperties & { tag: string; }> {
+	render() {
+		const registry = new MockRegistry();
+		registry.tag = this.properties.tag;
+		return v('div', {
+			key: 'wrapper'
+		}, [ w(RegistryWidgetChild, {
+			bind: this,
+			key: 'child',
+			registry
+		}) ]);
 	}
 }
 
@@ -185,6 +215,65 @@ registerSuite({
 				widget.expectRender(null);
 			}, Error, 'An expected render did not occur.');
 			widget.destroy();
+		},
+
+		'with comparison': {
+			'widget render - properties match'() {
+				const widget = harness(RegisterChildWidget);
+				widget.setProperties({
+					tag: 'foo'
+				});
+				let called = false;
+				const compareRegistry = compareProperty((value: MockRegistry, name, properties: RegistryWidgetProperties) => {
+					called = true;
+					assert.instanceOf(value, MockRegistry);
+					assert.strictEqual(name, 'registry');
+					assert.strictEqual(properties.key, 'child');
+					assert.isDefined(properties.bind);
+					return value.tag === 'foo';
+				});
+				widget.expectRender(v('div', { afterCreate: widget.listener, afterUpdate: widget.listener, key: 'wrapper' }, [
+					w<any>(RegistryWidgetChild, { bind: true, key: 'child', registry: compareRegistry })
+				]));
+				assert.isTrue(called, 'comparer should have been called');
+			},
+
+			'widget render - properties do not match'() {
+				const widget = harness(RegisterChildWidget);
+				widget.setProperties({
+					tag: 'bar'
+				});
+				let called = false;
+				const compareRegistry = compareProperty((value: MockRegistry) => {
+					called = true;
+					return value.tag === 'foo';
+				});
+				assert.throws(() => {
+					widget.expectRender(v('div', { afterCreate: widget.listener, afterUpdate: widget.listener, key: 'wrapper' }, [
+						w<any>(RegistryWidgetChild, { bind: true, key: 'child', registry: compareRegistry })
+					]));
+				}, AssertionError, 'The value of property "registry" is unexpected.');
+				assert.isTrue(called, 'comparer should have been called');
+			},
+
+			'widget render - primative value compare'() {
+				let uuid = 0;
+				class IDWidget extends WidgetBase<WidgetProperties> {
+					private _id = '_id' + ++uuid;
+
+					render() {
+						return v('div', { id: this._id });
+					}
+				}
+				const widget = harness(IDWidget);
+				let called = false;
+				const compareId = compareProperty((value: string) => {
+					called = true;
+					return value === `_id${uuid}`;
+				});
+				widget.expectRender(v('div', { id: compareId as any }));
+				assert.isTrue(called, 'comparer should have been called');
+			}
 		}
 	},
 

--- a/tests/unit/support/compare.ts
+++ b/tests/unit/support/compare.ts
@@ -1,6 +1,6 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
-import { createConstructRecord, diff, patch, ObjectDiff } from '../../../src/support/compare';
+import { createConstructRecord, diff, patch, CustomDiff } from '../../../src/support/compare';
 
 registerSuite({
 	name: 'compare',
@@ -297,13 +297,13 @@ registerSuite({
 					const a = {
 						foo: /foo/
 					};
-					const objectDiff = new ObjectDiff((value: RegExp, name, parent) => {
+					const customDiff = new CustomDiff((value: RegExp, name, parent) => {
 						called = true;
 						assert.instanceOf(value, RegExp, 'value should be a regualar expression');
 						assert.strictEqual(name, 'foo', 'name should equal "foo"');
 						assert.strictEqual(parent, a, 'correct parent should be passed');
 					});
-					const patchRecords = diff(a, { foo: objectDiff });
+					const patchRecords = diff(a, { foo: customDiff });
 					assert.isTrue(called, 'object differ should have been called');
 					assert.deepEqual(patchRecords, [], 'should have found no differences');
 				},
@@ -311,14 +311,14 @@ registerSuite({
 				'a object differ is called'() {
 					let called = false;
 					const b = { foo: /foo/ };
-					const objectDiff = new ObjectDiff((value: RegExp, name, parent) => {
+					const customDiff = new CustomDiff((value: RegExp, name, parent) => {
 						called = true;
 						assert.instanceOf(value, RegExp, 'value should be a regualar expression');
 						assert.strictEqual(name, 'foo', 'name should equal "foo"');
 						assert.strictEqual(parent, b, 'correct parent should be passed');
 					});
 					const a = {
-						foo: objectDiff
+						foo: customDiff
 					};
 					const patchRecords = diff(a, b);
 					assert.isTrue(called, 'object differ should have been called');
@@ -329,10 +329,10 @@ registerSuite({
 					const a = {
 						foo: /foo/
 					};
-					const objectDiff = new ObjectDiff(() => {
+					const customDiff = new CustomDiff(() => {
 						return createConstructRecord(RegExp);
 					});
-					const patchRecords = diff(a, { foo: objectDiff });
+					const patchRecords = diff(a, { foo: customDiff });
 					assert.deepEqual(patchRecords, [
 						{ Ctor: RegExp, name: 'foo' }
 					], 'should have expected patch records');
@@ -342,10 +342,10 @@ registerSuite({
 					const a = {
 						foo: /foo/
 					};
-					const objectDiff = new ObjectDiff(() => {
+					const customDiff = new CustomDiff(() => {
 						return createConstructRecord(RegExp, [ '/bar/' ]);
 					});
-					const patchRecords = diff(a, { foo: objectDiff });
+					const patchRecords = diff(a, { foo: customDiff });
 					assert.deepEqual(patchRecords, [
 						{ args: [ '/bar/' ], Ctor: RegExp, name: 'foo' }
 					], 'should have expected patch records');
@@ -355,30 +355,30 @@ registerSuite({
 					const a = {
 						foo: /foo/
 					};
-					const objectDiff = new ObjectDiff(() => {
+					const customDiff = new CustomDiff(() => {
 						return createConstructRecord(RegExp, undefined, { writable: true });
 					});
-					const patchRecords = diff(a, { foo: objectDiff });
+					const patchRecords = diff(a, { foo: customDiff });
 					assert.deepEqual(patchRecords, [
 						{ Ctor: RegExp, descriptor: { writable: true },  name: 'foo' }
 					], 'should have expected patch records');
 				},
 
 				'deleted property'() {
-					const objectDiff = new ObjectDiff(() => {
+					const customDiff = new CustomDiff(() => {
 						return createConstructRecord(RegExp);
 					});
-					const patchRecords = diff({ }, { foo: objectDiff });
+					const patchRecords = diff({ }, { foo: customDiff });
 					assert.deepEqual(patchRecords, [
 						{ name: 'foo', type: 'delete' }
 					], 'should have expected patch records');
 				},
 
 				'added property'() {
-					const objectDiff = new ObjectDiff(() => {
+					const customDiff = new CustomDiff(() => {
 						return createConstructRecord(RegExp);
 					});
-					const patchRecords = diff({ foo: objectDiff }, { });
+					const patchRecords = diff({ foo: customDiff }, { });
 					assert.deepEqual(patchRecords, [
 						{ Ctor: RegExp, name: 'foo' }
 					], 'should have expected patch records');

--- a/tests/unit/support/compare.ts
+++ b/tests/unit/support/compare.ts
@@ -1,6 +1,6 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
-import { diff, patch } from '../../../src/support/compare';
+import { createConstructRecord, diff, patch, ObjectDiff } from '../../../src/support/compare';
 
 registerSuite({
 	name: 'compare',
@@ -289,6 +289,100 @@ registerSuite({
 						type: 'add'
 					}
 				]);
+			},
+
+			'complex objects': {
+				'b object differ is called'() {
+					let called = false;
+					const a = {
+						foo: /foo/
+					};
+					const objectDiff = new ObjectDiff((value: RegExp, name, parent) => {
+						called = true;
+						assert.instanceOf(value, RegExp, 'value should be a regualar expression');
+						assert.strictEqual(name, 'foo', 'name should equal "foo"');
+						assert.strictEqual(parent, a, 'correct parent should be passed');
+					});
+					const patchRecords = diff(a, { foo: objectDiff });
+					assert.isTrue(called, 'object differ should have been called');
+					assert.deepEqual(patchRecords, [], 'should have found no differences');
+				},
+
+				'a object differ is called'() {
+					let called = false;
+					const b = { foo: /foo/ };
+					const objectDiff = new ObjectDiff((value: RegExp, name, parent) => {
+						called = true;
+						assert.instanceOf(value, RegExp, 'value should be a regualar expression');
+						assert.strictEqual(name, 'foo', 'name should equal "foo"');
+						assert.strictEqual(parent, b, 'correct parent should be passed');
+					});
+					const a = {
+						foo: objectDiff
+					};
+					const patchRecords = diff(a, b);
+					assert.isTrue(called, 'object differ should have been called');
+					assert.deepEqual(patchRecords, [], 'should have found no differences');
+				},
+
+				'difference'() {
+					const a = {
+						foo: /foo/
+					};
+					const objectDiff = new ObjectDiff(() => {
+						return createConstructRecord(RegExp);
+					});
+					const patchRecords = diff(a, { foo: objectDiff });
+					assert.deepEqual(patchRecords, [
+						{ Ctor: RegExp, name: 'foo' }
+					], 'should have expected patch records');
+				},
+
+				'difference with arguments'() {
+					const a = {
+						foo: /foo/
+					};
+					const objectDiff = new ObjectDiff(() => {
+						return createConstructRecord(RegExp, [ '/bar/' ]);
+					});
+					const patchRecords = diff(a, { foo: objectDiff });
+					assert.deepEqual(patchRecords, [
+						{ args: [ '/bar/' ], Ctor: RegExp, name: 'foo' }
+					], 'should have expected patch records');
+				},
+
+				'difference with descriptor'() {
+					const a = {
+						foo: /foo/
+					};
+					const objectDiff = new ObjectDiff(() => {
+						return createConstructRecord(RegExp, undefined, { writable: true });
+					});
+					const patchRecords = diff(a, { foo: objectDiff });
+					assert.deepEqual(patchRecords, [
+						{ Ctor: RegExp, descriptor: { writable: true },  name: 'foo' }
+					], 'should have expected patch records');
+				},
+
+				'deleted property'() {
+					const objectDiff = new ObjectDiff(() => {
+						return createConstructRecord(RegExp);
+					});
+					const patchRecords = diff({ }, { foo: objectDiff });
+					assert.deepEqual(patchRecords, [
+						{ name: 'foo', type: 'delete' }
+					], 'should have expected patch records');
+				},
+
+				'added property'() {
+					const objectDiff = new ObjectDiff(() => {
+						return createConstructRecord(RegExp);
+					});
+					const patchRecords = diff({ foo: objectDiff }, { });
+					assert.deepEqual(patchRecords, [
+						{ Ctor: RegExp, name: 'foo' }
+					], 'should have expected patch records');
+				}
 			},
 
 			'ignored properties': {
@@ -1662,6 +1756,103 @@ registerSuite({
 				assert.deepEqual(result, {
 					foo: 'bar'
 				});
+			}
+		},
+
+		'plain object with construct records': {
+			'basic property construct'() {
+				const result = patch({}, [
+					{ args: [ 'foo' ], Ctor: RegExp, name: 'foo' }
+				]);
+
+				assert.instanceOf(result.foo, RegExp, 'should be a regular expression');
+				assert.strictEqual(result.foo.toString(), '/foo/', 'should have a pattern of foo');
+			},
+
+			'property construct with descriptor'() {
+				const result = patch({}, [
+					{ args: [ 'foo' ], Ctor: RegExp, name: 'foo', descriptor: { writable: false, enumerable: false, configurable: false } },
+					{ args: [ 'foo' ], Ctor: RegExp, name: 'bar' }
+				]);
+
+				const descriptorFoo = Object.getOwnPropertyDescriptor(result, 'foo');
+				const descriptorBar = Object.getOwnPropertyDescriptor(result, 'bar');
+				assert.isFalse(descriptorFoo.writable);
+				assert.isFalse(descriptorFoo.enumerable);
+				assert.isFalse(descriptorFoo.configurable);
+				assert.instanceOf(descriptorFoo.value, RegExp);
+				assert.isTrue(descriptorBar.writable);
+				assert.isTrue(descriptorBar.enumerable);
+				assert.isTrue(descriptorBar.configurable);
+				assert.instanceOf(descriptorBar.value, RegExp);
+			},
+
+			'with property records'() {
+				class Foo {
+					foo: number;
+					bar: string;
+				}
+
+				const result = patch({}, [
+					{ Ctor: Foo, name: 'foo', propertyRecords:
+						[
+							{
+								descriptor: { configurable: true, enumerable: true, value: 1, writable: true },
+								name: 'foo',
+								type: 'add'
+							}, {
+								descriptor: { configurable: true, enumerable: true, value: 'baz', writable: true },
+								name: 'bar',
+								type: 'add'
+							}
+						]
+					}
+				]);
+
+				assert.instanceOf(result.foo, Foo, 'should be instance of Foo');
+				assert.strictEqual(result.foo.foo, 1, 'should have set property value');
+				assert.strictEqual(result.foo.bar, 'baz', 'should have set property value');
+			},
+
+			'with construct property records'() {
+				class Foo {
+					foo?: Foo;
+				}
+
+				const result = patch({}, [
+					{ Ctor: Foo, name: 'foo', propertyRecords: [
+							{
+								Ctor: Foo,
+								name: 'foo'
+							}
+						]
+					}
+				]);
+
+				assert.instanceOf(result.foo, Foo);
+				assert.instanceOf(result.foo.foo, Foo);
+			},
+
+			'plain object has complex property'() {
+				const result = patch({
+					foo: []
+				}, [
+					{
+						descriptor: { configurable: true, enumerable: true, value: { }, writable: true },
+						name: 'foo',
+						type: 'update',
+						valueRecords: [
+							{
+								args: [ 'foo' ],
+								Ctor: RegExp,
+								name: 'bar'
+							}
+						]
+					}
+				]);
+
+				assert.instanceOf(result.foo.bar, RegExp);
+				assert.strictEqual(result.foo.bar.toString(), '/foo/');
 			}
 		},
 

--- a/tests/unit/support/d.ts
+++ b/tests/unit/support/d.ts
@@ -3,6 +3,7 @@ import * as registerSuite from 'intern!object';
 import {
 	assignChildProperties,
 	assignProperties,
+	compareProperty,
 	findIndex,
 	findKey,
 	replaceChild,
@@ -11,6 +12,7 @@ import {
 } from '../../../src/support/d';
 
 import { v, w } from '@dojo/widget-core/d';
+import AssertionError from '../../../src/support/AssertionError';
 import assertRender from '../../../src/support/assertRender';
 
 registerSuite({
@@ -45,6 +47,33 @@ registerSuite({
 			assignProperties(actual, { styles: { 'font-weight': 'bold' } });
 
 			assertRender(actual, v('div', { styles: { 'font-weight': 'bold' } }, [ null, v('a', { href: '#link' }) ]));
+		}
+	},
+
+	'compareProperty()': {
+		'equals'() {
+			let called = false;
+			const obj = {};
+			const compareString = compareProperty((value: string, name, parent) => {
+				assert.strictEqual(name, 'bar');
+				assert.strictEqual(parent, obj);
+				called = true;
+				return value === 'foo';
+			});
+			assert.isUndefined(compareString.diff('foo', 'bar', obj));
+			assert.isTrue(called);
+		},
+
+		'unequal'() {
+			let called = false;
+			const compareNothing = compareProperty(() => {
+				called = true;
+				return false;
+			});
+			assert.throws(() => {
+				compareNothing.diff('foo', 'bar', {});
+			}, AssertionError, 'The value of property "bar" is unexpected.');
+			assert.isTrue(called);
 		}
 	},
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [X] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [X] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

This PR adds some features to enable custom comparisons of property values, specifically in `harness.expectRender()`:

- Add the class `support/compare/CustomDiff`, allowing the comparison of non-plain objects and custom comparison of primitives.
- `support/compare/diff` and `support/compare/patch` to support the `ConstructRecord` which allows for diffing and patching of non-plain Objects.
- Add `support/d/compareProperty` which wraps a function that returns `true` or `false` into a `CustomDiff` function.

As properties are compared via `diff`, if it encounters a `CustomDiff` it will off-load the comparison.  In the case of rendering, instead of returning a patch record, the `CustomDiff` will simply throw when the test function returns `false` indicating the value is unexpected.

Resolves #32 
