### PR TITLE
Add key to .sendEvent()

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,10 +241,11 @@ of the widget's rendered DOM.  The second is an optional object literal of addit
 
 |Option|Description|
 |------|-----------|
-|eventClass|A string that matches the class of event to use (e.g. `MouseEvent`).  By default, `CustomEvent` is used.|
-|eventInit|Any properties that should be part of initialising the event.  Note that `bubbles` and `cancelable` are `true` by default, which is different then if you were creating events directly.|
-|selector|A string selector to be applied to the root DOM element of the rendered widget.  This is intended to make it easy to sub-select a part of the widget's rendered DOM for targetting the event.|
-|target|By default, the widget's render root element is used.  This property subtitutes a specific target to dispatch the event to.|
+|`eventClass`|A string that matches the class of event to use (e.g. `MouseEvent`).  By default, `CustomEvent` is used.|
+|`eventInit`|Any properties that should be part of initialising the event.  Note that `bubbles` and `cancelable` are `true` by default, which is different then if you were creating events directly.|
+|`key`|A virtual DOM `key` that identifies the DOM node to dispatch an event to.  This is intended to make it easy to select a part of the widget's rendered DOM for targetting the event.|
+|`selector`|A string selector to be applied to the root DOM element of the rendered widget.  This is intended to make it easy to sub-select a part of the widget's rendered DOM for targetting the event.|
+|`target`|By default, the widget's render root element is used.  This property subtitutes a specific target to dispatch the event to.|
 
 Using event classes other than `CustomEvent` can sometimes be challenging, as cross browser support is sometimes difficult to acheive.
 In most use cases, assuming the widget is not expecting an event of a particular class, custom events should be fine.

--- a/README.md
+++ b/README.md
@@ -243,8 +243,8 @@ of the widget's rendered DOM.  The second is an optional object literal of addit
 |------|-----------|
 |`eventClass`|A string that matches the class of event to use (e.g. `MouseEvent`).  By default, `CustomEvent` is used.|
 |`eventInit`|Any properties that should be part of initialising the event.  Note that `bubbles` and `cancelable` are `true` by default, which is different then if you were creating events directly.|
-|`key`|A virtual DOM `key` that identifies the DOM node to dispatch an event to.  This is intended to make it easy to select a part of the widget's rendered DOM for targetting the event.|
-|`selector`|A string selector to be applied to the root DOM element of the rendered widget.  This is intended to make it easy to sub-select a part of the widget's rendered DOM for targetting the event.|
+|`key`|A virtual DOM `key` that identifies the DOM node to dispatch an event to.  Makes it easy to select a part of the widget's rendered DOM for targetting the event.|
+|`selector`|A string selector to be applied to the root DOM element of the rendered widget.  Makes it easy to sub-select a part of the widget's rendered DOM for targetting the event.|
 |`target`|By default, the widget's render root element is used.  This property subtitutes a specific target to dispatch the event to.|
 
 Using event classes other than `CustomEvent` can sometimes be challenging, as cross browser support is sometimes difficult to acheive.

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "grunt": "~1.0.1",
     "grunt-dojo2": "beta1",
     "intern": "^3.4.3",
-    "typescript": "~2.3.2"
+    "sinon": "^2.2.0",
+    "typescript": "^2.3.2"
   }
 }

--- a/src/harness.ts
+++ b/src/harness.ts
@@ -59,15 +59,13 @@ function findVNodebyKey(target: VNode, key: string | object): VNode | undefined 
 	if (typeof target === 'object' && target.children) {
 		target.children
 			.forEach((child) => {
-				if (typeof child === 'object') {
-					if (found) {
-						if (findVNodebyKey(child, key)) {
-							console.warn(`Duplicate key of "${key}" found.`);
-						}
+				if (found) {
+					if (findVNodebyKey(child, key)) {
+						console.warn(`Duplicate key of "${key}" found.`);
 					}
-					else {
-						found = findVNodebyKey(child, key);
-					}
+				}
+				else {
+					found = findVNodebyKey(child, key);
 				}
 			});
 	}

--- a/src/harness.ts
+++ b/src/harness.ts
@@ -47,6 +47,28 @@ const EVENT_HANDLERS = [
 ];
 
 /**
+ * An internal function which finds a VNode based on `key`
+ * @param target The VNode to search
+ * @param key The key to find
+ */
+function findVNodebyKey(target: VNode, key: string | object): VNode | undefined {
+	if (typeof target === 'object' && target.properties && target.properties.key === key) {
+		return target;
+	}
+	let found: VNode | undefined;
+	if (typeof target === 'object' && target.children) {
+		target.children
+			.some((child) => {
+				if (typeof child === 'object' && child.children) {
+					return Boolean(found = findVNodebyKey(child, key));
+				}
+				return false;
+			});
+	}
+	return found;
+}
+
+/**
  * Decorate a `DNode` where any `WNode`s are replaced with stubbed widgets
  * @param target The `DNode` to decorate with stubbed widgets
  */
@@ -169,6 +191,14 @@ class WidgetHarness<P extends WidgetProperties, W extends Constructor<WidgetBase
 }
 
 export interface HarnessSendEventOptions<I extends EventInit> extends SendEventOptions<I> {
+	/**
+	 * Find the target node by `key`
+	 */
+	key?: any;
+
+	/**
+	 * Provide an alternative target instead of the root DOM node
+	 */
 	target?: Element;
 }
 
@@ -198,13 +228,14 @@ export class Harness<P extends WidgetProperties, W extends Constructor<WidgetBas
 
 	private _children: DNode[] | undefined;
 	private _classes: string[] = [];
+	private _currentRender: VNode;
 	private _projection: Projection | undefined;
 	private _projectionOptions: ProjectionOptions;
 	private _projectionRoot: HTMLElement;
 	private _properties: P;
 
 	private _render = () => { /* using a lambda property here creates a bound function */
-		this._projection && this._projection.update(this._widgetHarnessRender() as VNode);
+		this._projection && this._projection.update(this._currentRender = this._widgetHarnessRender() as VNode);
 	}
 
 	private _root: HTMLElement | undefined;
@@ -249,7 +280,7 @@ export class Harness<P extends WidgetProperties, W extends Constructor<WidgetBas
 		this.own(this._widgetHarness.on('properties:changed', this._widgetHarness.invalidate));
 		this.own(this._widgetHarness.on('invalidated', this._render));
 
-		this._projection = dom.append(this._projectionRoot, this._widgetHarnessRender() as VNode, this._projectionOptions);
+		this._projection = dom.append(this._projectionRoot, this._currentRender = this._widgetHarnessRender() as VNode, this._projectionOptions);
 		this._attached = true;
 		return this._attached;
 	}
@@ -382,8 +413,17 @@ export class Harness<P extends WidgetProperties, W extends Constructor<WidgetBas
 	 *                        node to target, or provide the event initialisation properties
 	 */
 	public sendEvent<I extends EventInit>(type: string, options: HarnessSendEventOptions<I> = {}): this {
-		const { target = this.getDom() } = options;
-		sendEvent(target, type, options);
+		let { target = this.getDom(), key, ...sendOptions } = options;
+		if (key) {
+			const vnode = findVNodebyKey(this._currentRender, key);
+			if (vnode && vnode.domNode) {
+				target = vnode.domNode as Element;
+			}
+			else {
+				throw new Error(`Could not find key of "${key}" to sendEvent`);
+			}
+		}
+		sendEvent(target, type, sendOptions);
 		return this;
 	}
 

--- a/src/harness.ts
+++ b/src/harness.ts
@@ -58,11 +58,17 @@ function findVNodebyKey(target: VNode, key: string | object): VNode | undefined 
 	let found: VNode | undefined;
 	if (typeof target === 'object' && target.children) {
 		target.children
-			.some((child) => {
-				if (typeof child === 'object' && child.children) {
-					return Boolean(found = findVNodebyKey(child, key));
+			.forEach((child) => {
+				if (typeof child === 'object') {
+					if (found) {
+						if (findVNodebyKey(child, key)) {
+							console.warn(`Duplicate key of "${key}" found.`);
+						}
+					}
+					else {
+						found = findVNodebyKey(child, key);
+					}
 				}
-				return false;
 			});
 	}
 	return found;

--- a/src/support/d.ts
+++ b/src/support/d.ts
@@ -73,20 +73,32 @@ export function replaceChild(target: WNode | HNode, index: number | string, repl
 }
 
 function hasChildren(value: any): value is WNode | HNode {
-	return value && typeof value === 'object' && 'children' in value;
+	return value && typeof value === 'object' && value !== null;
 }
 
+/**
+ * Find a virtual DOM node (`WNode` or `HNode`) based on it having a matching `key` property.
+ *
+ * The function returns `undefined` if no node was found, otherwise it returns the node.  *NOTE* it will return the first node
+ * matching the supplied `key`, but will `console.warn` if more than one node was found.
+ */
 export function findKey(target: WNode | HNode, key: string | object): WNode | HNode | undefined {
 	if (target.properties.key === key) {
 		return target;
 	}
 	let found: WNode | HNode | undefined;
 	target.children
-		.some((child) => {
+		.forEach((child) => {
 			if (hasChildren(child)) {
-				return Boolean(found = findKey(child, key));
+				if (found) {
+					if (findKey(child, key)) {
+						console.warn(`Duplicate key of "${key}" found.`);
+					}
+				}
+				else {
+					found = findKey(child, key);
+				}
 			}
-			return false;
 		});
 	return found;
 }

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -58,6 +58,7 @@ export const loaderOptions = {
 		{ name: 'grunt-dojo2', location: 'node_modules/grunt-dojo2'},
 		{ name: 'maquette', location: 'node_modules/maquette/dist', main: 'maquette' },
 		{ name: 'pepjs', location: 'node_modules/pepjs/dist', main: 'pep' },
+		{ name: 'sinon', location: 'node_modules/sinon/pkg', main: 'sinon' },
 		{ name: 'src', location: '_build/src' },
 		{ name: 'tests', location: '_build/tests' }
 	]

--- a/tests/unit/harness.ts
+++ b/tests/unit/harness.ts
@@ -448,6 +448,82 @@ registerSuite({
 			assert.strictEqual(clickCount, 1);
 
 			widget.destroy();
+		},
+
+		'with key'() {
+			let clickCount = 0;
+			let target: any;
+
+			class ButtonWidget extends WidgetBase<WidgetProperties> {
+				private _tag = 'foo';
+
+				protected onClick(e: MouseEvent): boolean {
+					clickCount++;
+					e.preventDefault();
+					if ('CustomEvent' in window) {
+						assert.instanceOf(e, window['CustomEvent'], 'should be of class custom event');
+					}
+					assert.strictEqual(e.type, 'click', 'should be type of "click"');
+					assert.strictEqual(e.target, target, 'the target should be the rendered dom firstchild');
+					assert.strictEqual(this._tag, 'foo', '"this" should be an instance of the class');
+					return true;
+				}
+
+				render() {
+					return v('div', { key: 'wrap', onclick: this.onClick }, [ v('button', { key: 'button' }) ]);
+				}
+			}
+
+			const widget = harness(ButtonWidget);
+
+			assert.strictEqual(clickCount, 0);
+
+			target = widget.getDom().firstChild;
+
+			widget.sendEvent('click', {
+				key: 'button'
+			});
+
+			assert.strictEqual(clickCount, 1);
+
+			widget.destroy();
+		},
+
+		'with key not found'() {
+			class ButtonWidget extends WidgetBase<WidgetProperties> {
+				render() {
+					return v('div', { key: 'wrap' }, [ v('button', { key: 'button' }), 'foo', 'bar' ]);
+				}
+			}
+
+			const widget = harness(ButtonWidget);
+
+			assert.throws(() => {
+				widget.sendEvent('click', {
+					key: 'foo'
+				});
+			}, Error, 'Could not find key of "foo" to sendEvent');
+
+			widget.destroy();
+		},
+
+		'text only widget'() {
+			/* this is done for full code coverage */
+			class TextOnlyWidget extends WidgetBase<WidgetProperties> {
+				render() {
+					return 'text';
+				}
+			}
+
+			const widget = harness(TextOnlyWidget);
+
+			assert.throws(() => {
+				widget.sendEvent('click', {
+					key: 'foo'
+				});
+			}, Error, 'Could not find key of "foo" to sendEvent');
+
+			widget.destroy();
 		}
 	},
 

--- a/tests/unit/harness.ts
+++ b/tests/unit/harness.ts
@@ -512,11 +512,17 @@ registerSuite({
 			class DuplicateKeyWidget extends WidgetBase<WidgetProperties> {
 				render() {
 					return v('div', { key: 'foo' }, [
+						'foo',
 						v('span', { key: 'parent1' }, [
-							v('i', { key: 'icon', id: 'i1' })
+							v('i', { key: 'icon', id: 'i1' }, [ 'bar' ]),
+							'bar'
 						]),
 						v('span', { key: 'parent2' }, [
-							v('i', { key: 'icon', id: 'i2' })
+							v('i', { key: 'super-icon', id: 'i1' }, [ 'bar' ]),
+							'bar'
+						]),
+						v('span', { key: 'parent3' }, [
+							v('i', { key: 'icon', id: 'i2' }, [ 'bar' ])
 						])
 					]);
 				}

--- a/tests/unit/harness.ts
+++ b/tests/unit/harness.ts
@@ -6,6 +6,7 @@ import { compareProperty } from '../../src/support/d';
 import { v, w } from '@dojo/widget-core/d';
 import { WidgetProperties } from '@dojo/widget-core/interfaces';
 import WidgetBase from '@dojo/widget-core/WidgetBase';
+import { stub } from 'sinon';
 import AssertionError from '../../src/support/AssertionError';
 import assertRender from '../../src/support/assertRender';
 
@@ -505,6 +506,32 @@ registerSuite({
 			}, Error, 'Could not find key of "foo" to sendEvent');
 
 			widget.destroy();
+		},
+
+		'with duplicate key'() {
+			class DuplicateKeyWidget extends WidgetBase<WidgetProperties> {
+				render() {
+					return v('div', { key: 'foo' }, [
+						v('span', { key: 'parent1' }, [
+							v('i', { key: 'icon', id: 'i1' })
+						]),
+						v('span', { key: 'parent2' }, [
+							v('i', { key: 'icon', id: 'i2' })
+						])
+					]);
+				}
+			}
+
+			const warnStub = stub(console, 'warn');
+
+			const widget = harness(DuplicateKeyWidget);
+			widget.sendEvent('click', {
+				key: 'icon'
+			});
+			assert.strictEqual(warnStub.callCount, 1, 'should have been called once');
+			assert.strictEqual(warnStub.lastCall.args[0], 'Duplicate key of "icon" found.', 'should have logged duplicate key');
+
+			warnStub.restore();
 		},
 
 		'text only widget'() {

--- a/tests/unit/support/d.ts
+++ b/tests/unit/support/d.ts
@@ -214,14 +214,14 @@ registerSuite({
 		},
 
 		'value is WNode'() {
-			const vnode = w('widget', {
+			const vnode = w<any>('widget', {
 					onClick() { }
 				}, [
-					w('sub-widget', { key: 'foo', onClick() { } }),
-					w('sub-widget', { key: 'bar', onClick() { } })
+					w<any>('sub-widget', { key: 'foo', onClick() { } }),
+					w<any>('sub-widget', { key: 'bar', onClick() { } })
 				]);
 
-			assertRender(findKey(vnode, 'foo')!, w('sub-widget', { key: 'foo', onClick() { } }), 'should find widget');
+			assertRender(findKey(vnode, 'foo')!, w<any>('sub-widget', { key: 'foo', onClick() { } }), 'should find widget');
 		},
 
 		'duplicate keys warn'() {

--- a/tests/unit/support/d.ts
+++ b/tests/unit/support/d.ts
@@ -1,5 +1,6 @@
 import * as assert from 'intern/chai!assert';
 import * as registerSuite from 'intern!object';
+import { stub } from 'sinon';
 import {
 	assignChildProperties,
 	assignProperties,
@@ -213,12 +214,32 @@ registerSuite({
 		},
 
 		'value is WNode'() {
-			const vnode = v('div', { key: 'bar' }, [
-					w('widget', { key: 'baz' }),
-					w('widget', { key: 'foo' }, [ 'foo' ])
+			const vnode = w('widget', {
+					onClick() { }
+				}, [
+					w('sub-widget', { key: 'foo', onClick() { } }),
+					w('sub-widget', { key: 'bar', onClick() { } })
 				]);
 
-			assertRender(findKey(vnode, 'foo')!, w('widget', { key: 'foo' }, [ 'foo' ]), 'should find widget');
+			assertRender(findKey(vnode, 'foo')!, w('sub-widget', { key: 'foo', onClick() { } }), 'should find widget');
+		},
+
+		'duplicate keys warn'() {
+			const warnStub = stub(console, 'warn');
+
+			const fixture = v('div', { key: 'foo' }, [
+				v('span', { key: 'parent1' }, [
+					v('i', { key: 'icon', id: 'i1' })
+				]),
+				v('span', { key: 'parent2' }, [
+					v('i', { key: 'icon', id: 'i2' })
+				])
+			]);
+
+			assertRender(findKey(fixture, 'icon')!, v('i', { key: 'icon', id: 'i1' }), 'should find first key');
+			assert.strictEqual(warnStub.callCount, 1, 'should have been called once');
+			assert.strictEqual(warnStub.lastCall.args[0], 'Duplicate key of "icon" found.', 'should have logged duplicate key');
+			warnStub.restore();
 		}
 	},
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

This adds the feature where `key` can be passed to `.sendEvent()` on a harnessed widget to select the DOM node to dispatch the event to based on the virtual DOM key.

Resolves #22
