### PR TITLE
Use beta1 tag for widget-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@dojo/has": "beta1",
     "@dojo/i18n": "beta1",
     "@dojo/shim": "beta1",
-    "@dojo/widget-core": "latest",
+    "@dojo/widget-core": "beta1",
     "intern": "^3.4.3",
     "maquette": "2.4.3"
   },


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Updates the `@dojo/widget-core` dependency to the `beta1` tag.
