### PR TITLE
Change bind from ignore value to ignored property on assertRender

### DIFF
--- a/src/support/assertRender.ts
+++ b/src/support/assertRender.ts
@@ -37,7 +37,7 @@ function throwAssertionError(actual: any, expected: any, message?: string): neve
  */
 const defaultDiffOptions: DiffOptions = {
 	allowFunctionValues: true,
-	ignorePropertyValues: [ 'bind' ]
+	ignoreProperties: [ 'bind' ]
 };
 
 /**

--- a/tests/unit/harness.ts
+++ b/tests/unit/harness.ts
@@ -190,14 +190,14 @@ registerSuite({
 
 		'WNode children render - matches'() {
 			const widget = harness(SubWidget);
-			widget.expectRender(v('div', { }, [ w(MockWidget, { bind: true, key: 'first' }), w('widget', { bind: true, key: 'second' }) ]));
+			widget.expectRender(v('div', { }, [ w(MockWidget, { key: 'first' }), w('widget', { key: 'second' }) ]));
 			widget.destroy();
 		},
 
 		'WNode children render - does not match'() {
 			const widget = harness(SubWidget);
 			assert.throws(() => {
-				widget.expectRender(v('div', { }, [ w(MockWidget, { key: 'first' }), w('widget', { bind: true, key: 'second' }) ]));
+				widget.expectRender(v('div', { }, [ w(MockWidget, { key: 'fist' }), w('widget', { key: 'second' }) ]));
 			});
 			widget.destroy();
 		},

--- a/tests/unit/support/assertRender.ts
+++ b/tests/unit/support/assertRender.ts
@@ -305,7 +305,7 @@ registerSuite({
 			}, AssertionError, 'Render unexpected');
 		},
 
-		'bind poperty ignored'() {
+		'bind property ignored'() {
 			const bind = new MockWidget();
 			assertRender(
 				w(MockWidget, { bind }),

--- a/tests/unit/support/assertRender.ts
+++ b/tests/unit/support/assertRender.ts
@@ -305,32 +305,12 @@ registerSuite({
 			}, AssertionError, 'Render unexpected');
 		},
 
-		'bind value ignored'() {
+		'bind poperty ignored'() {
 			const bind = new MockWidget();
 			assertRender(
 				w(MockWidget, { bind }),
-				w(MockWidget, { bind: true })
+				w(MockWidget, { })
 			);
-		},
-
-		'bind extra'() {
-			const bind = new MockWidget();
-			assert.throws(() => {
-				assertRender(
-					w(MockWidget, { bind }),
-					w(MockWidget, { })
-				);
-			});
-		},
-
-		'bind missing'() {
-			const bind = new MockWidget();
-			assert.throws(() => {
-				assertRender(
-					w(MockWidget, { }),
-					w(MockWidget, { bind })
-				);
-			});
 		}
 	},
 
@@ -416,7 +396,7 @@ registerSuite({
 				const bind = new MockWidget();
 				assert.throws(() => {
 					assertRender(w(MockWidget, { bind }), w(MockWidget, { bind: true }), {
-						ignorePropertyValues: [ 'foo' ]
+						ignoreProperties: [ 'foo' ]
 					});
 				}, TypeError, 'Value of property named "bind" from first argument is not a primative, plain Object, or Array.');
 			}


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [X] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [X] Unit or Functional tests are included in the PR

**Description:**

Due to changes of the way virtual DOM nodes are bound in `widget-core` we should now wholly ignore `bind` in `assertRender()`.

Resolves #38 
