### PR TITLE
Remove bind references and and call _render explicitly

### DIFF
--- a/src/harness.ts
+++ b/src/harness.ts
@@ -316,10 +316,7 @@ export class Harness<P extends WidgetProperties, W extends Constructor<WidgetBas
 		}
 		else {
 			this._widgetHarness.invalidate();
-			this._widgetHarness.emit({
-				type: 'invalidated',
-				target: this
-			});
+			this._render();
 		}
 	}
 

--- a/src/harness.ts
+++ b/src/harness.ts
@@ -99,8 +99,8 @@ interface StubWidgetProperties extends WidgetProperties {
 
 class StubWidget extends WidgetBase<StubWidgetProperties> {
 	render(): DNode {
-		const { bind, _stubTag: tag, _widgetName: widgetName } = this.properties;
-		return v(tag, { bind, [WIDGET_STUB_NAME_PROPERTY]: widgetName }, this.children);
+		const { _stubTag: tag, _widgetName: widgetName } = this.properties;
+		return v(tag, { [WIDGET_STUB_NAME_PROPERTY]: widgetName }, this.children);
 	}
 }
 
@@ -316,6 +316,10 @@ export class Harness<P extends WidgetProperties, W extends Constructor<WidgetBas
 		}
 		else {
 			this._widgetHarness.invalidate();
+			this._widgetHarness.emit({
+				type: 'invalidated',
+				target: this
+			});
 		}
 	}
 

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -23,7 +23,7 @@ export const environments = [
 	{ browserName: 'edge' },
 	{ browserName: 'firefox', platform: 'WINDOWS' },
 	{ browserName: 'chrome', platform: 'WINDOWS' },
-	{ browserName: 'safari', version: '10', platform: 'MAC' },
+	{ browserName: 'safari', version: '9.1', platform: 'MAC' },
 	{ browserName: 'iPhone', version: '9.1' }
 ];
 

--- a/tests/unit/harness.ts
+++ b/tests/unit/harness.ts
@@ -49,7 +49,6 @@ class RegisterChildWidget extends WidgetBase<WidgetProperties & { tag: string; }
 		return v('div', {
 			key: 'wrapper'
 		}, [ w(RegistryWidgetChild, {
-			bind: this,
 			key: 'child',
 			registry
 		}) ]);
@@ -58,7 +57,7 @@ class RegisterChildWidget extends WidgetBase<WidgetProperties & { tag: string; }
 
 class SubWidget extends WidgetBase<WidgetProperties> {
 	render() {
-		return v('div', { }, [ w(MockWidget, { bind: this, key: 'first' }), w('widget', { bind: this, key: 'second' }) ]);
+		return v('div', { }, [ w(MockWidget, { key: 'first' }), w('widget', { key: 'second' }) ]);
 	}
 }
 
@@ -231,11 +230,10 @@ registerSuite({
 					assert.instanceOf(value, MockRegistry);
 					assert.strictEqual(name, 'registry');
 					assert.strictEqual(properties.key, 'child');
-					assert.isDefined(properties.bind);
 					return value.tag === 'foo';
 				});
 				widget.expectRender(v('div', { afterCreate: widget.listener, afterUpdate: widget.listener, key: 'wrapper' }, [
-					w<any>(RegistryWidgetChild, { bind: true, key: 'child', registry: compareRegistry })
+					w<any>(RegistryWidgetChild, { key: 'child', registry: compareRegistry })
 				]));
 				assert.isTrue(called, 'comparer should have been called');
 			},
@@ -252,7 +250,7 @@ registerSuite({
 				});
 				assert.throws(() => {
 					widget.expectRender(v('div', { afterCreate: widget.listener, afterUpdate: widget.listener, key: 'wrapper' }, [
-						w<any>(RegistryWidgetChild, { bind: true, key: 'child', registry: compareRegistry })
+						w<any>(RegistryWidgetChild, { key: 'child', registry: compareRegistry })
 					]));
 				}, AssertionError, 'The value of property "registry" is unexpected.');
 				assert.isTrue(called, 'comparer should have been called');
@@ -357,18 +355,18 @@ registerSuite({
 			class DynamicWidget extends WidgetBase<DynamicWidgetProperties> {
 				render() {
 					return this.properties.flag ?
-						v('div', { }, [ w(MockWidget, { bind: this, key: 'first' }), w(MockWidget, { bind: this, key: 'second' }) ]) :
-						v('div', { }, [ w(MockWidget, { bind: this, key: 'first' }) ]);
+						v('div', { }, [ w(MockWidget, { key: 'first' }), w(MockWidget, { key: 'second' }) ]) :
+						v('div', { }, [ w(MockWidget, { key: 'first' }) ]);
 				}
 			}
 
 			const widget = harness(DynamicWidget);
 
 			widget.setProperties({ flag: false });
-			widget.expectRender(v('div', { }, [ w(MockWidget, { bind: true, key: 'first' }) ]));
+			widget.expectRender(v('div', { }, [ w(MockWidget, { key: 'first' }) ]));
 
 			widget.setProperties({ flag: true });
-			widget.expectRender(v('div', { }, [ w(MockWidget, { bind: true, key: 'first' }), w(MockWidget, { bind: true, key: 'second' }) ]));
+			widget.expectRender(v('div', { }, [ w(MockWidget, { key: 'first' }), w(MockWidget, { key: 'second' }) ]));
 
 			widget.destroy();
 		}
@@ -572,8 +570,8 @@ registerSuite({
 							rootClick++;
 						}
 					}, [
-						w(MockWidget, { bind: this, onClick() { firstClick++; }, key: 'first' }),
-						w<MockWidget>('widget', { bind: this, onClick() { secondClick++; }, key: 'second' })
+						w(MockWidget, { onClick() { firstClick++; }, key: 'first' }),
+						w<MockWidget>('widget', { onClick() { secondClick++; }, key: 'second' })
 					]);
 				}
 			}
@@ -596,8 +594,8 @@ registerSuite({
 							rootClick++;
 						}
 					}, [
-						w(MockWidget, { bind: this, onClick() { firstClick++; }, key: 'first' }),
-						w<MockWidget>('widget', { bind: this, onClick() { secondClick++; }, key: 'second' })
+						w(MockWidget, { onClick() { firstClick++; }, key: 'first' }),
+						w<MockWidget>('widget', { onClick() { secondClick++; }, key: 'second' })
 					]);
 				}
 			}
@@ -620,8 +618,8 @@ registerSuite({
 							rootClick++;
 						}
 					}, [
-						w(MockWidget, { bind: this, onClick() { firstClick++; }, key: 'first' }),
-						w<MockWidget>('widget', { bind: this, onClick() { secondClick++; }, key: 'second' })
+						w(MockWidget, { onClick() { firstClick++; }, key: 'first' }),
+						w<MockWidget>('widget', { onClick() { secondClick++; }, key: 'second' })
 					]);
 				}
 			}
@@ -637,7 +635,7 @@ registerSuite({
 			class ComplexSubWidget extends WidgetBase<WidgetProperties> {
 				render() {
 					return v('div', { }, [
-						w(MockWidget, { bind: this, onClick(this: any) {
+						w(MockWidget, { onClick(this: any) {
 							assert.instanceOf(this, ComplexSubWidget, 'should call with bound scope');
 						}, key: 'first' })
 					]);

--- a/tests/unit/support/assertRender.ts
+++ b/tests/unit/support/assertRender.ts
@@ -308,7 +308,7 @@ registerSuite({
 		'bind property ignored'() {
 			const bind = new MockWidget();
 			assertRender(
-				w(MockWidget, { bind }),
+				w(MockWidget, <any> { bind }),
 				w(MockWidget, { })
 			);
 		}
@@ -395,7 +395,7 @@ registerSuite({
 			'overrides defaults'() {
 				const bind = new MockWidget();
 				assert.throws(() => {
-					assertRender(w(MockWidget, { bind }), w(MockWidget, { bind: true }), {
+					assertRender(w<any>(MockWidget, { bind }), w<any>(MockWidget, { bind: true }), {
 						ignoreProperties: [ 'foo' ]
 					});
 				}, TypeError, 'Value of property named "bind" from first argument is not a primative, plain Object, or Array.');


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Upgrade to support changes in widget-core. 1) removal of `bind` property 2) change to invalidating during the properties change lifecycle.

Needs release of widget-core.
