### PR TITLE
Remove re-render on invalidated

### DIFF
--- a/src/harness.ts
+++ b/src/harness.ts
@@ -282,7 +282,6 @@ export class Harness<P extends WidgetProperties, W extends Constructor<WidgetBas
 
 		this.own(this._widgetHarness.on('widget:children', this._widgetHarness.invalidate));
 		this.own(this._widgetHarness.on('properties:changed', this._widgetHarness.invalidate));
-		this.own(this._widgetHarness.on('invalidated', this._render));
 
 		this._projection = dom.append(this._projectionRoot, this._currentRender = this._widgetHarnessRender() as VNode, this._projectionOptions);
 		this._attached = true;

--- a/tests/unit/harness.ts
+++ b/tests/unit/harness.ts
@@ -218,6 +218,29 @@ registerSuite({
 			widget.destroy();
 		},
 
+		'self invalidation does not break render'() {
+			let called = false;
+			class SelfInvalidateWidget extends WidgetBase {
+				onClick = () => {
+					called = true;
+					this.invalidate();
+				}
+
+				render() {
+					return v('div', {
+						onClick: this.onClick
+					});
+				}
+			}
+
+			const widget = harness(SelfInvalidateWidget);
+			widget.callListener('onClick');
+			assert.isTrue(called);
+			widget.expectRender(v('div', {
+				onClick: widget.listener
+			}));
+		},
+
 		'with comparison': {
 			'widget render - properties match'() {
 				const widget = harness(RegisterChildWidget);


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [X] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [X] Unit or Functional tests are included in the PR

**Description:**

This PR removes re-rendering on `invalidated`.  The harness should proactively control the renender process otherwise it might miss attempts to assert the rerender when the widget isn't otherwise dirty (e.g. when a widget with no children self-invalidates).

Resolves #45 
