### PR TITLE
Ignore ignored properties in diff from assertRender

### DIFF
--- a/src/support/assertRender.ts
+++ b/src/support/assertRender.ts
@@ -2,7 +2,7 @@ import { assign } from '@dojo/core/lang';
 import { isHNode, isWNode } from '@dojo/widget-core/d';
 import { DNode, HNode, WNode } from '@dojo/widget-core/interfaces';
 import AssertionError from './AssertionError';
-import { diff, DiffOptions } from './compare';
+import {diff, DiffOptions, getComparableObjects} from './compare';
 
 const RENDER_FAIL_MESSAGE = 'Render unexpected';
 
@@ -92,7 +92,8 @@ export default function assertRender(actual: DNode, expected: DNode, options?: A
 		const delta = diff(actual.properties, expected.properties, diffOptions);
 		if (delta.length) {
 			/* The properties do not match */
-			throwAssertionError(actual.properties, expected.properties, message);
+			const { comparableA, comparableB } = getComparableObjects(actual.properties, expected.properties, diffOptions);
+			throwAssertionError(comparableA, comparableB, message);
 		}
 		/* We need to assert the children match */
 		assertChildren(actual.children, expected.children);

--- a/src/support/compare.ts
+++ b/src/support/compare.ts
@@ -449,7 +449,8 @@ function diffPlainObject(a: any, b: any, options: DiffOptions): (ConstructRecord
 
 export function getComparableObjects(a: any, b: any, options: DiffOptions) {
 	const { ignoreProperties = [], ignorePropertyValues = [] } = options;
-	const ignored = new Set<string>();
+	const ignore = new Set<string>();
+	const keep = new Set<string>();
 
 	function isIgnoredProperty(name: string) {
 		return Array.isArray(ignoreProperties) ? ignoreProperties.some((value) => {
@@ -460,16 +461,17 @@ export function getComparableObjects(a: any, b: any, options: DiffOptions) {
 	const comparableA = keys(a).reduce((obj, name) => {
 		if (isIgnoredProperty(name) ||
 			hasOwnProperty.call(b, name) && isIgnoredPropertyValue(name, a, b, ignorePropertyValues)) {
-				ignored.add(name);
+				ignore.add(name);
 				return obj;
 		}
 
+		keep.add(name);
 		obj[name] = a[name];
 		return obj;
 	}, {} as any);
 
 	const comparableB = keys(b).reduce((obj, name) => {
-		if (ignored.has(name) || isIgnoredProperty(name)) {
+		if (ignore.has(name) || !keep.has(name) && isIgnoredProperty(name)) {
 			return obj;
 		}
 
@@ -477,7 +479,7 @@ export function getComparableObjects(a: any, b: any, options: DiffOptions) {
 		return obj;
 	}, {} as any);
 
-	return { comparableA, comparableB, ignored };
+	return { comparableA, comparableB, ignore };
 }
 
 /**

--- a/src/support/compare.ts
+++ b/src/support/compare.ts
@@ -1,5 +1,6 @@
 import { assign } from '@dojo/core/lang';
 import { keys } from '@dojo/shim/object';
+import Set from '@dojo/shim/Set';
 
 /* Assigning to local variables to improve minification and readability */
 
@@ -379,78 +380,65 @@ function diffArray(a: any[], b: any, options: DiffOptions): SpliceRecord[] {
  * @param options An options bag that allows configuration of the behaviour of `diffPlainObject()`
  */
 function diffPlainObject(a: any, b: any, options: DiffOptions): (ConstructRecord | PatchRecord)[] {
-	const { allowFunctionValues = false, ignoreProperties = [], ignorePropertyValues = [] } = options;
+	const { allowFunctionValues = false, ignorePropertyValues = [] } = options;
 	const patchRecords: (ConstructRecord | PatchRecord)[] = [];
-
-	function isIgnoredProperty(name: string) {
-		return Array.isArray(ignoreProperties) ? ignoreProperties.some((value) => {
-			return typeof value === 'string' ? name === value : value.test(name);
-		}) : ignoreProperties(name, a, b);
-	}
-
-	function isIgnoredPropertyValue(name: string) {
-		return Array.isArray(ignorePropertyValues) ? ignorePropertyValues.some((value) => {
-			return typeof value === 'string' ? name === value : value.test(name);
-		}) : ignorePropertyValues(name, a, b);
-	}
+	const { comparableA, comparableB } = getComparableObjects(a, b, options);
 
 	/* look for keys in a that are different from b */
-	keys(a).reduce((patchRecords, name) => {
-		if (!isIgnoredProperty(name)) {
-			const valueA = a[name];
-			const valueB = b[name];
-			const bHasOwnProperty = hasOwnProperty.call(b, name);
+	keys(comparableA).reduce((patchRecords, name) => {
+		const valueA = a[name];
+		const valueB = b[name];
+		const bHasOwnProperty = hasOwnProperty.call(comparableB, name);
 
-			if (bHasOwnProperty && (valueA === valueB ||
-				(allowFunctionValues && typeof valueA === 'function' && typeof valueB === 'function') ||
-				isIgnoredPropertyValue(name))) { /* not different */
-					/* when `allowFunctionValues` is true, functions are simply considered to be equal by `typeof` */
-					return patchRecords;
-			}
+		if (bHasOwnProperty && (valueA === valueB ||
+			(allowFunctionValues && typeof valueA === 'function' && typeof valueB === 'function'))) { /* not different */
+				/* when `allowFunctionValues` is true, functions are simply considered to be equal by `typeof` */
+				return patchRecords;
+		}
 
-			const type = bHasOwnProperty ? 'update' : 'add';
+		const type = bHasOwnProperty ? 'update' : 'add';
 
-			const isValueAArray = isArray(valueA);
-			const isValueAPlainObject = isPlainObject(valueA);
+		const isValueAArray = isArray(valueA);
+		const isValueAPlainObject = isPlainObject(valueA);
 
-			if ((isValueAArray || isValueAPlainObject) && !isIgnoredPropertyValue(name)) { /* non-primitive values we can diff */
-				/* this is a bit complicated, but essentially if valueA and valueB are both arrays or plain objects, then
-				* we can diff those two values, if not, then we need to use an empty array or an empty object and diff
-				* the valueA with that */
-				const value = (isValueAArray && isArray(valueB)) || (isValueAPlainObject && isPlainObject(valueB)) ?
-					valueB : isValueAArray ?
-						[] : objectCreate(null);
-				const valueRecords = diff(valueA, value, options);
-				if (valueRecords.length) { /* only add if there are changes */
-					patchRecords.push(createPatchRecord(type, name, createValuePropertyDescriptor(value), diff(valueA, value, options)));
-				}
+		if ((isValueAArray || isValueAPlainObject)) { /* non-primitive values we can diff */
+			/* this is a bit complicated, but essentially if valueA and valueB are both arrays or plain objects, then
+			* we can diff those two values, if not, then we need to use an empty array or an empty object and diff
+			* the valueA with that */
+			const value = (isValueAArray && isArray(valueB)) || (isValueAPlainObject && isPlainObject(valueB)) ?
+				valueB : isValueAArray ?
+					[] : objectCreate(null);
+			const valueRecords = diff(valueA, value, options);
+			if (valueRecords.length) { /* only add if there are changes */
+				patchRecords.push(createPatchRecord(type, name, createValuePropertyDescriptor(value), diff(valueA, value, options)));
 			}
-			else if (isCustomDiff(valueA) && !isCustomDiff(valueB)) { /* complex diff left hand */
-				const result = valueA.diff(valueB, name, b);
-				if (result) {
-					patchRecords.push(result);
-				}
+		}
+		else if (isCustomDiff(valueA) && !isCustomDiff(valueB)) { /* complex diff left hand */
+			const result = valueA.diff(valueB, name, b);
+			if (result) {
+				patchRecords.push(result);
 			}
-			else if (isCustomDiff(valueB)) { /* complex diff right hand */
-				const result = valueB.diff(valueA, name, a);
-				if (result) {
-					patchRecords.push(result);
-				}
+		}
+		else if (isCustomDiff(valueB)) { /* complex diff right hand */
+			const result = valueB.diff(valueA, name, a);
+			if (result) {
+				patchRecords.push(result);
 			}
-			else if (isPrimitive(valueA) || (allowFunctionValues && typeof valueA === 'function') || isIgnoredPropertyValue(name)) {
+		}
+		else if (isPrimitive(valueA) || (allowFunctionValues && typeof valueA === 'function') ||
+			isIgnoredPropertyValue(name, a, b, ignorePropertyValues)) {
 				/* primitive values, functions values if allowed, or ignored property values can just be copied */
 				patchRecords.push(createPatchRecord(type, name, createValuePropertyDescriptor(valueA)));
-			}
-			else {
-				throw new TypeError(`Value of property named "${name}" from first argument is not a primative, plain Object, or Array.`);
-			}
+		}
+		else {
+			throw new TypeError(`Value of property named "${name}" from first argument is not a primative, plain Object, or Array.`);
 		}
 		return patchRecords;
 	}, patchRecords);
 
 	/* look for keys in b that are not in a */
-	keys(b).reduce((patchRecords, name) => {
-		if (!hasOwnProperty.call(a, name) && !isIgnoredProperty(name)) {
+	keys(comparableB).reduce((patchRecords, name) => {
+		if (!hasOwnProperty.call(comparableA, name)) {
 			patchRecords.push(createPatchRecord('delete', name));
 		}
 		return patchRecords;
@@ -459,12 +447,51 @@ function diffPlainObject(a: any, b: any, options: DiffOptions): (ConstructRecord
 	return patchRecords;
 }
 
+export function getComparableObjects(a: any, b: any, options: DiffOptions) {
+	const { ignoreProperties = [], ignorePropertyValues = [] } = options;
+	const ignored = new Set<string>();
+
+	function isIgnoredProperty(name: string) {
+		return Array.isArray(ignoreProperties) ? ignoreProperties.some((value) => {
+			return typeof value === 'string' ? name === value : value.test(name);
+		}) : ignoreProperties(name, a, b);
+	}
+
+	const comparableA = keys(a).reduce((obj, name) => {
+		if (isIgnoredProperty(name) ||
+			hasOwnProperty.call(b, name) && isIgnoredPropertyValue(name, a, b, ignorePropertyValues)) {
+				ignored.add(name);
+				return obj;
+		}
+
+		obj[name] = a[name];
+		return obj;
+	}, {} as any);
+
+	const comparableB = keys(b).reduce((obj, name) => {
+		if (ignored.has(name) || isIgnoredProperty(name)) {
+			return obj;
+		}
+
+		obj[name] = b[name];
+		return obj;
+	}, {} as any);
+
+	return { comparableA, comparableB, ignored };
+}
+
 /**
  * A guard that determines if the value is a `ConstructRecord`
  * @param value The value to check
  */
 function isConstructRecord(value: any): value is ConstructRecord {
 	return Boolean(value && typeof value === 'object' && value !== null && value.Ctor && value.name);
+}
+
+function isIgnoredPropertyValue(name: string, a: any, b: any, ignoredPropertyValues: (string | RegExp)[] | IgnorePropertyFunction) {
+	return Array.isArray(ignoredPropertyValues) ? ignoredPropertyValues.some((value) => {
+		return typeof value === 'string' ? name === value : value.test(name);
+	}) : ignoredPropertyValues(name, a, b);
 }
 
 /**

--- a/tests/unit/support/assertRender.ts
+++ b/tests/unit/support/assertRender.ts
@@ -413,11 +413,12 @@ registerSuite({
 					}
 				});
 			} catch (err) {
-				assert.deepEqual(err, new AssertionError('Render unexpected', {
-					actual: { foo: 'bar' },
-					expected: { foo: 'baz' },
-					showDiff: true
-				}, assertRender), 'Should have excluded ignored properties from error');
+				assert.deepEqual(
+					err.actual, { foo: 'bar' }, 'Should have excluded ignored properties from "actual" value'
+				);
+				assert.deepEqual(
+					err.expected, { foo: 'baz' }, 'Should have excluded ignored properties from "expected" value'
+				);
 			}
 		}
 	}

--- a/tests/unit/support/assertRender.ts
+++ b/tests/unit/support/assertRender.ts
@@ -400,6 +400,25 @@ registerSuite({
 					});
 				}, TypeError, 'Value of property named "bind" from first argument is not a primative, plain Object, or Array.');
 			}
+		},
+
+		'diff should exclude ignored properties and property values'() {
+			try {
+				assertRender(v('div', { foo: 'bar', bar: 2, baz: 2 }), v('div', { foo: 'baz', baz: 3 }), {
+					ignoreProperties(prop): boolean {
+						return prop === 'bar';
+					},
+					ignorePropertyValues(prop): boolean {
+						return prop === 'baz';
+					}
+				});
+			} catch (err) {
+				assert.deepEqual(err, new AssertionError('Render unexpected', {
+					actual: { foo: 'bar' },
+					expected: { foo: 'baz' },
+					showDiff: true
+				}, assertRender), 'Should have excluded ignored properties from error');
+			}
 		}
 	}
 });

--- a/tests/unit/support/compare.ts
+++ b/tests/unit/support/compare.ts
@@ -543,6 +543,32 @@ registerSuite({
 					} });
 
 					assert.deepEqual(patchRecords, [], 'should be no differences');
+					assert.deepEqual(propertyStack, [ 'foo', 'bar', 'baz', 'foo', 'bar', 'baz' ]);
+				},
+
+				'function and ignored'() {
+					const propertyStack: string[] = [];
+
+					const a = {
+						foo: 'bar',
+						bar: 1,
+						baz: false
+					};
+
+					const b = {
+						foo: 'bar',
+						bar: 1,
+						baz: false
+					};
+
+					const patchRecords = diff(a, b, { ignoreProperties(name, first, second) {
+						propertyStack.push(name);
+						assert.strictEqual(first, a);
+						assert.strictEqual(second, b);
+						return true;
+					} });
+
+					assert.deepEqual(patchRecords, [], 'should be no differences');
 					assert.deepEqual(propertyStack, [ 'foo', 'bar', 'baz' ]);
 				}
 			},

--- a/tests/unit/support/compare.ts
+++ b/tests/unit/support/compare.ts
@@ -543,7 +543,7 @@ registerSuite({
 					} });
 
 					assert.deepEqual(patchRecords, [], 'should be no differences');
-					assert.deepEqual(propertyStack, [ 'foo', 'bar', 'baz', 'foo', 'bar', 'baz' ]);
+					assert.deepEqual(propertyStack, [ 'foo', 'bar', 'baz' ]);
 				},
 
 				'function and ignored'() {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Instead of checking each property during comparison for whether it's ignored, this frontloads that and creates new objects with only those properties that should be compared. That same logic is then used to generate a new "actual" and "expected" for the error message if there are differences.

Resolves #42 

Example of error message from widgets before these changes:
```
× TextInput - simple (0.001s)
AssertionError: Render unexpected

    "aria-controls": undefined,
    "aria-describedby": undefined,
    "aria-invalid": null,
    "aria-readonly": null,
A   "bind": {
A     "_allClasses": {
A       "textinput-m__inputWrapper__qgMQw": false,
A       "textinput-m__input__2KJg7": false,
A       "textinput-m__root__FUuHt": false
A     },
A     "_baseThemeClassesReverseLookup": {
A       "dojo-textinput": " _key",
A       "textinput-m__disabled__302VV": "disabled",
A       "textinput-m__inputWrapper__qgMQw": "inputWrapper",
A       "textinput-m__input__2KJg7": "input",
A       "textinput-m__invalid__CqUAw": "invalid",
A       "textinput-m__readonly__3qX-J": "readonly",
A       "textinput-m__required__55ZjP": "required",
A       "textinput-m__root__FUuHt": "root",
A       "textinput-m__valid__Qu18X": "valid"
A     },
A     "_bindFunctionPropertyMap": {},
A     "_cachedChildrenMap": {},
A     "_children": [
A       length: 0
A     ],
A     "_decoratorCache": {},
A     "_diffPropertyFunctionMap": {},
A     "_dirty": false,
A     "_previousProperties": {
A       "bind": {
A         "_afterCreate": <anonymous>({}),
A         "_bindFunctionPropertyMap": {},
A         "_cachedChildrenMap": {},
A         "_children": [
A           length: 0
A         ],
A         "_decoratorCache": {},
A         "_diffPropertyFunctionMap": {},
A         "_dirty": false,
A         "_id": "test--harness-20",
A         "_previousProperties": {},
A         "_properties": {
A           "bind": [Circular]
A         },
A         "_registries": {
A           "_registries": [
A             0: {
A               "registry": {
A                 "handles": [
A                   length: 0
A                 ],
A                 "listenersMap": {},
A                 "on": <anonymous>({}),
A                 "registry": {}
A               }
A             },
A             length: 1
A           ],
A           "handles": [
A             length: 0
A           ],
A           "listenersMap": {},
A           "on": <anonymous>({})
A         },
A         "_renderDecorators": {},
A         "_renderState": 3,
A         "_widgetConstructor": SpyRender({}),
A         "assertionMessage": undefined,
A         "didRender": true,
A         "expectedRender": undefined,
A         "handles": [
A           0: {
A             "_registries": [
A               0: {
A                 "registry": {
A                   "handles": [
A                     length: 0
A                   ],
A                   "listenersMap": {},
A                   "on": <anonymous>({}),
A                   "registry": {}
A                 }
A               },
A               length: 1
A             ],
A             "handles": [
A               length: 0
A             ],
A             "listenersMap": {},
A             "on": <anonymous>({})
A           },
A           1: {
A             "destroy": destroy({})
A           },
A           2: {
A             "destroy": destroy({})
A           },
A           3: [Circular],
A           length: 4
A         ],
A         "lastRender": {
A           "children": [
A             0: {
A               "children": [
A                 0: {
A                   "children": [
A                     length: 0
A                   ],
A                   "properties": [Circular],
A                   "render": render({}),
A                   "tag": "input",
A                   "type": Symbol(Identifier for a HNode.)
A                 },
A                 length: 1
A               ],
A               "properties": {
A                 "bind": [Circular],
A                 "classes": {
A                   "textinput-m__inputWrapper__qgMQw": true,
A                   "textinput-m__input__2KJg7": false
A                 }
A               },
A               "render": render({}),
A               "tag": "div",
A               "type": Symbol(Identifier for a HNode.)
A             },
A             length: 1
A           ],
A           "properties": {
A             "bind": [Circular],
A             "classes": {
A               "textinput-m__inputWrapper__qgMQw": false,
A               "textinput-m__input__2KJg7": false,
A               "textinput-m__root__FUuHt": true
A             }
A           },
A           "render": render({}),
A           "tag": "div",
A           "type": Symbol(Identifier for a HNode.)
A         },
A         "listenersMap": {},
A         "on": <anonymous>({}),
A         "renderCount": 1
A       }
A     },
A     "_properties": {
A       "bind": {
A         "_afterCreate": <anonymous>({}),
A         "_bindFunctionPropertyMap": {},
A         "_cachedChildrenMap": {},
A         "_children": [
A           length: 0
A         ],
A         "_decoratorCache": {},
A         "_diffPropertyFunctionMap": {},
A         "_dirty": false,
A         "_id": "test--harness-20",
A         "_previousProperties": {},
A         "_properties": {
A           "bind": [Circular]
A         },
A         "_registries": {
A           "_registries": [
A             0: {
A               "registry": {
A                 "handles": [
A                   length: 0
A                 ],
A                 "listenersMap": {},
A                 "on": <anonymous>({}),
A                 "registry": {}
A               }
A             },
A             length: 1
A           ],
A           "handles": [
A             length: 0
A           ],
A           "listenersMap": {},
A           "on": <anonymous>({})
A         },
A         "_renderDecorators": {},
A         "_renderState": 3,
A         "_widgetConstructor": SpyRender({}),
A         "assertionMessage": undefined,
A         "didRender": true,
A         "expectedRender": undefined,
A         "handles": [
A           0: {
A             "_registries": [
A               0: {
A                 "registry": {
A                   "handles": [
A                     length: 0
A                   ],
A                   "listenersMap": {},
A                   "on": <anonymous>({}),
A                   "registry": {}
A                 }
A               },
A               length: 1
A             ],
A             "handles": [
A               length: 0
A             ],
A             "listenersMap": {},
A             "on": <anonymous>({})
A           },
A           1: {
A             "destroy": destroy({})
A           },
A           2: {
A             "destroy": destroy({})
A           },
A           3: [Circular],
A           length: 4
A         ],
A         "lastRender": {
A           "children": [
A             0: {
A               "children": [
A                 0: {
A                   "children": [
A                     length: 0
A                   ],
A                   "properties": [Circular],
A                   "render": render({}),
A                   "tag": "input",
A                   "type": Symbol(Identifier for a HNode.)
A                 },
A                 length: 1
A               ],
A               "properties": {
A                 "bind": [Circular],
A                 "classes": {
A                   "textinput-m__inputWrapper__qgMQw": true,
A                   "textinput-m__input__2KJg7": false
A                 }
A               },
A               "render": render({}),
A               "tag": "div",
A               "type": Symbol(Identifier for a HNode.)
A             },
A             length: 1
A           ],
A           "properties": {
A             "bind": [Circular],
A             "classes": {
A               "textinput-m__inputWrapper__qgMQw": false,
A               "textinput-m__input__2KJg7": false,
A               "textinput-m__root__FUuHt": true
A             }
A           },
A           "render": render({}),
A           "tag": "div",
A           "type": Symbol(Identifier for a HNode.)
A         },
A         "listenersMap": {},
A         "on": <anonymous>({}),
A         "renderCount": 1
A       }
A     },
A     "_recalculateClasses": false,
A     "_registeredBaseThemes": [
A       0: {
A         " _key": "dojo-textinput",
A         "disabled": "textinput-m__disabled__302VV",
A         "input": "textinput-m__input__2KJg7",
A         "inputWrapper": "textinput-m__inputWrapper__qgMQw",
A         "invalid": "textinput-m__invalid__CqUAw",
A         "readonly": "textinput-m__readonly__3qX-J",
A         "required": "textinput-m__required__55ZjP",
A         "root": "textinput-m__root__FUuHt",
A         "valid": "textinput-m__valid__Qu18X"
A       },
A       length: 1
A     ],
A     "_registeredClassesMap": {},
A     "_registries": {
A       "_registries": [
A         0: {
A           "registry": {
A             "handles": [
A               length: 0
A             ],
A             "listenersMap": {},
A             "on": <anonymous>({}),
A             "registry": {}
A           }
A         },
A         length: 1
A       ],
A       "handles": [
A         length: 0
A       ],
A       "listenersMap": {},
A       "on": <anonymous>({})
A     },
A     "_renderDecorators": {},
A     "_renderState": 3,
A     "_theme": {},
A     "handles": [
A       0: {
A         "_registries": [
A           0: {
A             "registry": {
A               "handles": [
A                 length: 0
A               ],
A               "listenersMap": {},
A               "on": <anonymous>({}),
A               "registry": {}
A             }
A           },
A           length: 1
A         ],
A         "handles": [
A           length: 0
A         ],
A         "listenersMap": {},
A         "on": <anonymous>({})
A       },
A       1: {
A         "destroy": destroy({})
A       },
A       2: {
A         "destroy": destroy({})
A       },
A       3: {
A         "destroy": destroy({})
A       },
A       length: 4
A     ],
A     "listenersMap": {},
A     "on": <anonymous>({})
A   },
    "classes": {
      "textinput-m__input__2KJg7": true
    },
    "disabled": undefined,
[...]
    "placeholder": undefined,
    "readOnly": undefined,
    "required": undefined,
    "type": "text",
E   "value": undefined,
E   "whoopsy": "bad"
A   "value": undefined
  }
```
And after:
```
× TextInput - simple (0.007s)
AssertionError: Render unexpected

    "placeholder": undefined,
    "readOnly": undefined,
    "required": undefined,
    "type": "text",
E   "value": undefined,
E   "whoopsy": "bad"
A   "value": undefined
  }

```

