### PR TITLE
Support array of DNodes for expectRender

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,28 +27,27 @@
     "test": "grunt test"
   },
   "peerDependencies": {
-    "@dojo/core": "beta1",
-    "@dojo/has": "beta1",
-    "@dojo/i18n": "beta1",
-    "@dojo/shim": "beta1",
-    "@dojo/widget-core": "beta1",
-    "intern": "^3.4.3",
-    "maquette": "2.4.3"
+    "@dojo/core": "next",
+    "@dojo/has": "next",
+    "@dojo/i18n": "next",
+    "@dojo/shim": "next",
+    "@dojo/widget-core": "next",
+    "intern": "^3.4.3"
   },
   "dependencies": {
     "jsdom": "^10.0.0",
     "pepjs": "^0.4.2"
   },
   "devDependencies": {
-    "@dojo/interfaces": "beta1",
-    "@dojo/loader": "beta1",
+    "@dojo/interfaces": "next",
+    "@dojo/loader": "next",
     "@types/chai": "3.4.*",
     "@types/glob": "5.0.*",
     "@types/grunt": "0.4.*",
     "@types/jsdom": "2.0.*",
     "@types/sinon": "^1.16.31",
     "grunt": "~1.0.1",
-    "grunt-dojo2": "beta1",
+    "grunt-dojo2": "latest",
     "intern": "^3.4.3",
     "sinon": "^2.2.0",
     "typescript": "^2.3.2"

--- a/src/harness.ts
+++ b/src/harness.ts
@@ -125,7 +125,7 @@ function SpyRenderMixin<T extends Constructor<WidgetBaseInterface<WidgetProperti
 			target.actualRender(result);
 			return stubRender(result);
 		}
-	};
+	}
 
 	return SpyRender;
 }
@@ -150,7 +150,7 @@ class WidgetHarness<P extends WidgetProperties, W extends Constructor<WidgetBase
 	/**
 	 * What `DNode` that is expected on the next render
 	 */
-	public expectedRender: DNode | undefined;
+	public expectedRender: DNode | DNode[] | undefined;
 
 	/**
 	 * A reference to the previous render
@@ -366,7 +366,7 @@ export class Harness<P extends WidgetProperties, W extends Constructor<WidgetBas
 	 * @param expected The expected render (`DNode`)
 	 * @param message Any message to be part of an error that gets thrown if the actual and expected do not match
 	 */
-	public expectRender(expected: DNode, message?: string): this {
+	public expectRender(expected: DNode | DNode[], message?: string): this {
 		this._widgetHarness.expectedRender = expected;
 		this._widgetHarness.assertionMessage = message;
 		this._widgetHarness.didRender = false;

--- a/src/support/assertRender.ts
+++ b/src/support/assertRender.ts
@@ -51,14 +51,14 @@ const defaultDiffOptions: DiffOptions = {
  * }, [ w(SubWidget, { open: true }) ]));
  * ```
  *
- * @param actual The actual rendered DNode to be asserted
- * @param expected The expected DNode to be asserted against the actual
+ * @param actual The actual rendered DNode or DNode Array to be asserted
+ * @param expected The expected DNode or DNode Array to be asserted against the actual
  * @param options A set of options that effect the behaviour of `assertRender`
  * @param message Any message to be part of an error thrown if actual and expected do not match
  */
-export default function assertRender(actual: DNode, expected: DNode, message?: string): void;
-export default function assertRender(actual: DNode, expected: DNode, options: AssertRenderOptions, message?: string): void;
-export default function assertRender(actual: DNode, expected: DNode, options?: AssertRenderOptions | string, message?: string): void {
+export default function assertRender(actual: DNode | DNode[], expected: DNode | DNode[], message?: string): void;
+export default function assertRender(actual: DNode | DNode[], expected: DNode | DNode[], options: AssertRenderOptions, message?: string): void;
+export default function assertRender(actual: DNode | DNode[], expected: DNode | DNode[], options?: AssertRenderOptions | string, message?: string): void {
 	if (typeof options === 'string') {
 		message = options;
 		options = undefined;
@@ -75,7 +75,13 @@ export default function assertRender(actual: DNode, expected: DNode, options?: A
 		});
 	}
 
-	if ((localIsHNode(actual) && localIsHNode(expected)) || (localIsWNode(actual) && localIsWNode(expected))) {
+	if (Array.isArray(actual) && Array.isArray(expected)) {
+		assertChildren(actual, expected);
+	}
+	else if (Array.isArray(actual) || Array.isArray(expected)) {
+		throwAssertionError(actual, expected, message);
+	}
+	else if ((localIsHNode(actual) && localIsHNode(expected)) || (localIsWNode(actual) && localIsWNode(expected))) {
 		if (localIsHNode(actual) && localIsHNode(expected)) {
 			if (actual.tag !== expected.tag) {
 				/* The tags do not match */

--- a/tests/unit/harness.ts
+++ b/tests/unit/harness.ts
@@ -28,6 +28,14 @@ class MockWidget extends WidgetBase<MockWidgetProperties> {
 	}
 }
 
+class MockArrayWidget extends WidgetBase<MockWidgetProperties> {
+	render() {
+		return [
+			v('div.foo')
+		];
+	}
+}
+
 class MockRegistry {
 	tag: string;
 }
@@ -179,10 +187,72 @@ registerSuite({
 			widget.destroy();
 		},
 
+		'HNode render array - matches'() {
+			const widget = harness(MockArrayWidget);
+			widget.expectRender([ v('div.foo') ]);
+			widget.destroy();
+		},
+
+		'HNode render null - matches'() {
+			class MockWidget extends WidgetBase {
+				render() {
+					return null;
+				}
+			}
+			const widget = harness(MockWidget);
+			widget.expectRender(null);
+			widget.destroy();
+		},
+
+		'HNode render string - matches'() {
+			class MockWidget extends WidgetBase {
+				render() {
+					return 'string';
+				}
+			}
+			const widget = harness(MockWidget);
+			widget.expectRender('string');
+			widget.destroy();
+		},
+
 		'HNode render - does not match'() {
 			const widget = harness(MockWidget);
 			assert.throws(() => {
 				widget.expectRender(v('div.bar'));
+			});
+			widget.destroy();
+		},
+
+		'HNode render array - does not match'() {
+			const widget = harness(MockWidget);
+			assert.throws(() => {
+				widget.expectRender([ v('div.baz') ]);
+			});
+			widget.destroy();
+		},
+
+		'HNode render null - does not matches'() {
+			class MockWidget extends WidgetBase {
+				render() {
+					return null;
+				}
+			}
+			const widget = harness(MockWidget);
+			assert.throws(() => {
+				widget.expectRender([ v('div.baz') ]);
+			});
+			widget.destroy();
+		},
+
+		'HNode render string - does not matches'() {
+			class MockWidget extends WidgetBase {
+				render() {
+					return 'string';
+				}
+			}
+			const widget = harness(MockWidget);
+			assert.throws(() => {
+				widget.expectRender([ v('div.baz') ]);
 			});
 			widget.destroy();
 		},

--- a/tests/unit/support/assertRender.ts
+++ b/tests/unit/support/assertRender.ts
@@ -35,6 +35,31 @@ registerSuite({
 			);
 		},
 
+		'array HNodes equal'() {
+			assertRender(
+				[ v('div'), v('span') ],
+				[ v('div'), v('span') ]
+			);
+		},
+
+		'actual HNodes array and expected HNode not equal'() {
+			assert.throws(() => {
+				assertRender(
+					[ v('div'), v('span') ],
+					v('div')
+				);
+			}, AssertionError, 'Render unexpected');
+		},
+
+		'expected HNode and expected HNode array not equal'() {
+			assert.throws(() => {
+				assertRender(
+					v('div'),
+					[ v('div'), v('span') ]
+				);
+			}, AssertionError, 'Render unexpected');
+		},
+
 		'tag difference'() {
 			assert.throws(() => {
 				assertRender(v('div'), v('span'));
@@ -152,6 +177,13 @@ registerSuite({
 			assertRender(
 				w(MockWidget, {}),
 				w(MockWidget, {})
+			);
+		},
+
+		'WNode array equal'() {
+			assertRender(
+				[ w(MockWidget, {}) ],
+				[ w(MockWidget, {}) ]
 			);
 		},
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Support an array of `DNode`s when using `Harness#expectRender` and `assertRender`.

Resolves #49 
