### PR TITLE
Remove listeners on WidgetBase events and expose invalidate

### DIFF
--- a/src/harness.ts
+++ b/src/harness.ts
@@ -192,6 +192,10 @@ class WidgetHarness<P extends WidgetProperties, W extends Constructor<WidgetBase
 				[ w(_widgetConstructor, properties, children) ]
 			);
 	}
+
+	public invalidate(): void {
+		super.invalidate();
+	}
 }
 
 export interface HarnessSendEventOptions<I extends EventInit> extends SendEventOptions<I> {
@@ -279,9 +283,6 @@ export class Harness<P extends WidgetProperties, W extends Constructor<WidgetBas
 			this._projection = undefined;
 			this._attached = false;
 		}));
-
-		this.own(this._widgetHarness.on('widget:children', this._widgetHarness.invalidate));
-		this.own(this._widgetHarness.on('properties:changed', this._widgetHarness.invalidate));
 
 		this._projection = dom.append(this._projectionRoot, this._currentRender = this._widgetHarnessRender() as VNode, this._projectionOptions);
 		this._attached = true;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Remove listeners on `WidgetBase` events `properties:changed` and `widget:children` as they are not required and expose `invalidate` for the harness due to it being protected in the next widget-core release.

Resolves #52 
