### PR TITLE
restrict TS version to '~'

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     "grunt-dojo2": "latest",
     "intern": "^3.4.3",
     "sinon": "^2.2.0",
-    "typescript": "^2.3.2"
+    "typescript": "~2.3.2"
   }
 }


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Should restrict TS version to builds not automatically update on minors.
