### PR TITLE
Add better default error message for mismatched strings

### DIFF
--- a/src/support/assertRender.ts
+++ b/src/support/assertRender.ts
@@ -108,7 +108,7 @@ export default function assertRender(actual: DNode | DNode[], expected: DNode | 
 		/* Both DNodes are strings */
 		if (actual !== expected) {
 			/* The strings do not match */
-			throwAssertionError(actual, expected, message || `Expected ${actual} to equal ${expected}`);
+			throwAssertionError(actual, expected, message || `Expected "${actual}" to equal "${expected}"`);
 		}
 	}
 	else if (!(actual === null && expected === null)) {

--- a/src/support/assertRender.ts
+++ b/src/support/assertRender.ts
@@ -108,7 +108,7 @@ export default function assertRender(actual: DNode | DNode[], expected: DNode | 
 		/* Both DNodes are strings */
 		if (actual !== expected) {
 			/* The strings do not match */
-			throwAssertionError(actual, expected, message);
+			throwAssertionError(actual, expected, message || `Expected ${actual} to equal ${expected}`);
 		}
 	}
 	else if (!(actual === null && expected === null)) {

--- a/tests/unit/support/assertRender.ts
+++ b/tests/unit/support/assertRender.ts
@@ -121,6 +121,15 @@ registerSuite({
 			);
 		},
 
+		'string children unequal'() {
+			assert.throws(() => {
+				assertRender(
+					v('div', { }, [ 'foo' ]),
+					v('div', { }, [ 'bar' ])
+				);
+			}, 'AssertionError: Render unexpected: Expected foo to equal bar');
+		},
+
 		'missing child'() {
 			assert.throws(() => {
 				assertRender(

--- a/tests/unit/support/assertRender.ts
+++ b/tests/unit/support/assertRender.ts
@@ -127,7 +127,7 @@ registerSuite({
 					v('div', { }, [ 'foo' ]),
 					v('div', { }, [ 'bar' ])
 				);
-			}, 'AssertionError: Render unexpected: Expected foo to equal bar');
+			}, 'AssertionError: Render unexpected: Expected "foo" to equal "bar"');
 		},
 
 		'missing child'() {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
This adds a default message for when `assertRender` fails comparing strings. In contrast to the error in #56, this is the error for the same failure with this change.

```
AssertionError: Render unexpected: Expected "foo" to equal "bar"
  at <_build\src\support\assertRender.js:141:17>
  at Array.forEach  <native>
  at assertChildren  <_build\src\support\assertRender.js:138:20>
  at Object.assertRender [as default]  <_build\src\support\assertRender.js:202:21>
  at Test.string children unequal [as test]  <tests\unit\support\assertRender.ts:126:5>
  at <node_modules\intern\lib\Test.js:191:24>
  at <node_modules\intern\browser_modules\dojo\Promise.ts:393:15>
  at runCallbacks  <node_modules\intern\browser_modules\dojo\Promise.ts:11:11>
  at <node_modules\intern\browser_modules\dojo\Promise.ts:317:4>
  at run  <node_modules\intern\browser_modules\dojo\Promise.ts:237:7>

```

Resolves #56 
