### PR TITLE
Add better comparison logic for the DNode classes property

### DIFF
--- a/src/support/assertRender.ts
+++ b/src/support/assertRender.ts
@@ -143,10 +143,12 @@ export default function assertRender(actual: DNode | DNode[], expected: DNode | 
 			}
 		}
 		/* Inject a custom comparator for class names */
-		const expectedClasses: SupportedClassName[] | undefined = expected.properties && (expected.properties as any).classes;
+		const expectedClasses: SupportedClassName | SupportedClassName[] = expected.properties && (expected.properties as any).classes;
 		if (expectedClasses && !isCustomDiff(expectedClasses)) {
-			(expected.properties as any).classes = compareProperty((value?: SupportedClassName[]) => {
-				const expectedSet = new Set(expectedClasses.filter(expectedClass => Boolean(expectedClass)));
+			(expected.properties as any).classes = compareProperty((value: SupportedClassName | SupportedClassName[]) => {
+				const expectedValue = (typeof expectedClasses === 'string' ? [ expectedClasses ] : expectedClasses) || [];
+				value = (typeof value === 'string' ? [ value ] : value) || [];
+				const expectedSet = new Set(expectedValue.filter(expectedClass => Boolean(expectedClass)));
 				const actualSet = new Set((value || []).filter(actualClass => Boolean(actualClass)));
 
 				if (expectedSet.size !== actualSet.size) {
@@ -158,7 +160,8 @@ export default function assertRender(actual: DNode | DNode[], expected: DNode | 
 					allMatch = allMatch && expectedSet.has(actualClass);
 				});
 				return allMatch;
-			});
+			}
+);
 		}
 		const delta = diff(actual.properties, expected.properties, diffOptions);
 		if (delta.length) {

--- a/src/support/assertRender.ts
+++ b/src/support/assertRender.ts
@@ -146,10 +146,10 @@ export default function assertRender(actual: DNode | DNode[], expected: DNode | 
 		const expectedClasses: SupportedClassName | SupportedClassName[] = expected.properties && (expected.properties as any).classes;
 		if (expectedClasses && !isCustomDiff(expectedClasses)) {
 			(expected.properties as any).classes = compareProperty((value: SupportedClassName | SupportedClassName[]) => {
-				const expectedValue = (typeof expectedClasses === 'string' ? [ expectedClasses ] : expectedClasses) || [];
+				const expectedValue = typeof expectedClasses === 'string' ? [ expectedClasses ] : expectedClasses;
 				value = (typeof value === 'string' ? [ value ] : value) || [];
 				const expectedSet = new Set(expectedValue.filter(expectedClass => Boolean(expectedClass)));
-				const actualSet = new Set((value || []).filter(actualClass => Boolean(actualClass)));
+				const actualSet = new Set(value.filter(actualClass => Boolean(actualClass)));
 
 				if (expectedSet.size !== actualSet.size) {
 					return false;

--- a/src/support/assertRender.ts
+++ b/src/support/assertRender.ts
@@ -1,8 +1,10 @@
 import { assign } from '@dojo/core/lang';
+import Set from '@dojo/shim/Set';
 import { isHNode, isWNode } from '@dojo/widget-core/d';
-import { DNode, HNode, WNode } from '@dojo/widget-core/interfaces';
+import { DNode, HNode, WNode, SupportedClassName } from '@dojo/widget-core/interfaces';
 import AssertionError from './AssertionError';
-import {diff, DiffOptions, getComparableObjects} from './compare';
+import { diff, DiffOptions, getComparableObjects, isCustomDiff } from './compare';
+import { compareProperty } from './d';
 
 const RENDER_FAIL_MESSAGE = 'Render unexpected';
 
@@ -139,6 +141,24 @@ export default function assertRender(actual: DNode | DNode[], expected: DNode | 
 				/* The WNode does not share the same constructor */
 				throwAssertionError(actual.widgetConstructor, expected.widgetConstructor, `WNodes do not share constructor`, message);
 			}
+		}
+		/* Inject a custom comparator for class names */
+		const expectedClasses: SupportedClassName[] | undefined = expected.properties && (expected.properties as any).classes;
+		if (expectedClasses && !isCustomDiff(expectedClasses)) {
+			(expected.properties as any).classes = compareProperty((value?: SupportedClassName[]) => {
+				const expectedSet = new Set(expectedClasses.filter(expectedClass => Boolean(expectedClass)));
+				const actualSet = new Set((value || []).filter(actualClass => Boolean(actualClass)));
+
+				if (expectedSet.size !== actualSet.size) {
+					return false;
+				}
+
+				let allMatch = true;
+				actualSet.forEach(actualClass => {
+					allMatch = allMatch && expectedSet.has(actualClass);
+				});
+				return allMatch;
+			});
 		}
 		const delta = diff(actual.properties, expected.properties, diffOptions);
 		if (delta.length) {

--- a/src/support/compare.ts
+++ b/src/support/compare.ts
@@ -376,7 +376,7 @@ function diffArray(a: any[], b: any, options: DiffOptions): SpliceRecord[] {
  * describe the differences
  *
  * @param a The first plain object to compare to
- * @param b The second plain bject to compare to
+ * @param b The second plain object to compare to
  * @param options An options bag that allows configuration of the behaviour of `diffPlainObject()`
  */
 function diffPlainObject(a: any, b: any, options: DiffOptions): (ConstructRecord | PatchRecord)[] {

--- a/src/support/compare.ts
+++ b/src/support/compare.ts
@@ -400,20 +400,7 @@ function diffPlainObject(a: any, b: any, options: DiffOptions): (ConstructRecord
 
 		const isValueAArray = isArray(valueA);
 		const isValueAPlainObject = isPlainObject(valueA);
-
-		if ((isValueAArray || isValueAPlainObject)) { /* non-primitive values we can diff */
-			/* this is a bit complicated, but essentially if valueA and valueB are both arrays or plain objects, then
-			* we can diff those two values, if not, then we need to use an empty array or an empty object and diff
-			* the valueA with that */
-			const value = (isValueAArray && isArray(valueB)) || (isValueAPlainObject && isPlainObject(valueB)) ?
-				valueB : isValueAArray ?
-					[] : objectCreate(null);
-			const valueRecords = diff(valueA, value, options);
-			if (valueRecords.length) { /* only add if there are changes */
-				patchRecords.push(createPatchRecord(type, name, createValuePropertyDescriptor(value), diff(valueA, value, options)));
-			}
-		}
-		else if (isCustomDiff(valueA) && !isCustomDiff(valueB)) { /* complex diff left hand */
+		if (isCustomDiff(valueA) && !isCustomDiff(valueB)) { /* complex diff left hand */
 			const result = valueA.diff(valueB, name, b);
 			if (result) {
 				patchRecords.push(result);
@@ -423,6 +410,18 @@ function diffPlainObject(a: any, b: any, options: DiffOptions): (ConstructRecord
 			const result = valueB.diff(valueA, name, a);
 			if (result) {
 				patchRecords.push(result);
+			}
+		}
+		else if ((isValueAArray || isValueAPlainObject)) { /* non-primitive values we can diff */
+			/* this is a bit complicated, but essentially if valueA and valueB are both arrays or plain objects, then
+			* we can diff those two values, if not, then we need to use an empty array or an empty object and diff
+			* the valueA with that */
+			const value = (isValueAArray && isArray(valueB)) || (isValueAPlainObject && isPlainObject(valueB)) ?
+				valueB : isValueAArray ?
+					[] : objectCreate(null);
+			const valueRecords = diff(valueA, value, options);
+			if (valueRecords.length) { /* only add if there are changes */
+				patchRecords.push(createPatchRecord(type, name, createValuePropertyDescriptor(value), diff(valueA, value, options)));
 			}
 		}
 		else if (isPrimitive(valueA) || (allowFunctionValues && typeof valueA === 'function') ||
@@ -490,6 +489,14 @@ export function getComparableObjects(a: any, b: any, options: DiffOptions) {
 }
 
 /**
+ * A guard that determines if the value is a `CustomDiff`
+ * @param value The value to check
+ */
+export function isCustomDiff<T>(value: any): value is CustomDiff<T> {
+	return typeof value === 'object' && value instanceof CustomDiff;
+}
+
+/**
  * A guard that determines if the value is a `ConstructRecord`
  * @param value The value to check
  */
@@ -548,14 +555,6 @@ function isPrimitive(value: any): value is (string | number | boolean | undefine
 		typeofValue === 'string' ||
 		typeofValue === 'number' ||
 		typeofValue === 'boolean';
-}
-
-/**
- * A guard that determines if the value is a `CustomDiff`
- * @param value The value to check
- */
-function isCustomDiff<T>(value: any): value is CustomDiff<T> {
-	return typeof value === 'object' && value instanceof CustomDiff;
 }
 
 /**

--- a/src/support/d.ts
+++ b/src/support/d.ts
@@ -23,7 +23,7 @@ export function assignProperties(target: WNode | HNode, properties: WidgetProper
 
 /**
  * Creates a function which, when placed in an expected render, will call the `callback`.  If the `callback` returns `true`, the value
- * of the property is considered equal, otherwise it is considerd not equal and the expected render will fail.
+ * of the property is considered equal, otherwise it is considered not equal and the expected render will fail.
  * @param callback A function that is invoked when comparing the property value
  */
 export function compareProperty<T>(callback: (value: T, name: string, parent: WidgetProperties | VirtualDomProperties) => boolean): CustomDiff<T> {
@@ -40,7 +40,7 @@ export function compareProperty<T>(callback: (value: T, name: string, parent: Wi
  *
  * *NOTE:* The replacement modifies the passed `target` and does not return a new instance of the `DNode`.
  * @param target The DNode to replace a child element on
- * @param index A number of the index of a child, or a string with comma seperated indexes that would nagivate
+ * @param index A number of the index of a child, or a string with comma separated indexes that would nagivate
  * @param replacement The DNode to be replaced
  */
 export function replaceChild(target: WNode | HNode, index: number | string, replacement: DNode): WNode | HNode {

--- a/tests/unit/harness.ts
+++ b/tests/unit/harness.ts
@@ -343,7 +343,7 @@ registerSuite('harness', {
 				assert.isTrue(called, 'comparer should have been called');
 			},
 
-			'widget render - primative value compare'() {
+			'widget render - primitive value compare'() {
 				let uuid = 0;
 				class IDWidget extends WidgetBase<WidgetProperties> {
 					private _id = '_id' + ++uuid;
@@ -360,6 +360,34 @@ registerSuite('harness', {
 				});
 				widget.expectRender(v('div', { id: compareId as any }));
 				assert.isTrue(called, 'comparer should have been called');
+			},
+			'widget render - object value compare'() {
+				class ObjectWidget extends WidgetBase<WidgetProperties> {
+					render() {
+						return v('div', { object: { value: 3 } });
+					}
+				}
+				const widget = harness(ObjectWidget);
+				const comparisonStub = stub().callsFake((object: { value: number }) => {
+					return object.value === 3;
+				});
+				const compareId = compareProperty(comparisonStub);
+				widget.expectRender(v('div', { object: compareId as any }));
+				assert.isTrue(comparisonStub.calledOnce, 'comparer should have been called');
+			},
+			'widget render - array value compare'() {
+				class ArrayWidget extends WidgetBase<WidgetProperties> {
+					render() {
+						return v('div', { array: [ 3 ] });
+					}
+				}
+				const widget = harness(ArrayWidget);
+				const comparisonStub = stub().callsFake((array: number[]) => {
+					return array.length === 1 && array[0] === 3;
+				});
+				const compareId = compareProperty(comparisonStub);
+				widget.expectRender(v('div', { array : compareId as any }));
+				assert.isTrue(comparisonStub.calledOnce, 'comparer should have been called');
 			}
 		}
 	},

--- a/tests/unit/support/assertRender.ts
+++ b/tests/unit/support/assertRender.ts
@@ -8,6 +8,7 @@ import WidgetBase from '@dojo/widget-core/WidgetBase';
 import { HNode, WidgetProperties, WNode } from '@dojo/widget-core/interfaces';
 
 interface MockWidgetProperties extends WidgetProperties {
+	classes?: (string | undefined | null)[];
 	foo?: string;
 	bar?: number;
 	baz?: () => void;
@@ -123,7 +124,7 @@ registerSuite('support/assertRender', {
 			}, AssertionError, 'Render unexpected: Expected children');
 		},
 
-		'unepxected children'() {
+		'unexpected children'() {
 			assert.throws(() => {
 				assertRender(
 					v('div', {}, []),
@@ -216,6 +217,20 @@ registerSuite('support/assertRender', {
 					v('div', { }, [ v('span', {}, [ w(MockWidget, { foo: 'baz', baz() { } }) ]) ])
 				);
 			}, AssertionError, 'Render unexpected');
+		},
+
+		'compare unique classes only'() {
+			assertRender(
+				v('div', { classes: [ 'foo', null, 'bar' ] }),
+				v('div',  { classes: [ null,  'bar', 'foo', undefined ] })
+			);
+
+			assert.throws(() => {
+				assertRender(
+					v('div', { classes: [ 'foo', null, 'bar' ] }),
+					v('div',  { classes: [ 'foo',  null, 'baz' ] })
+				);
+			}, AssertionError, 'The value of property "classes" is unexpected.');
 		}
 	},
 
@@ -390,6 +405,20 @@ registerSuite('support/assertRender', {
 				w(MockWidget, <any> { bind }),
 				w(MockWidget, { })
 			);
+		},
+
+		'compare unique classes only'() {
+			assertRender(
+				w(MockWidget, { classes: [ 'foo', null, 'bar' ] }),
+				w(MockWidget,  { classes: [ null,  'bar', 'foo', undefined ] })
+			);
+
+			assert.throws(() => {
+				assertRender(
+					w(MockWidget, { classes: [ 'foo', null, 'bar' ] }),
+					w(MockWidget,  { classes: [ 'foo',  null, 'baz' ] })
+				);
+			}, AssertionError, 'The value of property "classes" is unexpected.');
 		}
 	},
 

--- a/tests/unit/support/assertRender.ts
+++ b/tests/unit/support/assertRender.ts
@@ -5,10 +5,10 @@ import AssertionError from '../../../src/support/AssertionError';
 import assertRender from '../../../src/support/assertRender';
 import { v, w } from '@dojo/widget-core/d';
 import WidgetBase from '@dojo/widget-core/WidgetBase';
-import { HNode, WidgetProperties, WNode } from '@dojo/widget-core/interfaces';
+import { HNode, SupportedClassName, WidgetProperties, WNode } from '@dojo/widget-core/interfaces';
 
 interface MockWidgetProperties extends WidgetProperties {
-	classes?: (string | undefined | null)[];
+	classes?: SupportedClassName | SupportedClassName[];
 	foo?: string;
 	bar?: number;
 	baz?: () => void;
@@ -226,9 +226,26 @@ registerSuite('support/assertRender', {
 			);
 
 			assertRender(
-				v('div', { classes: null as any }),
+				v('div', { classes: null }),
 				v('div', { classes: [] })
 			);
+
+			assertRender(
+				v('div', { classes: 'foo' }),
+				v('div', { classes: [ 'foo' ] })
+			);
+
+			assertRender(
+				v('div', { classes: 'foo' }),
+				v('div', { classes: 'foo' })
+			);
+
+			assert.throws(() => {
+				assertRender(
+					v('div', { classes: 'foo' }),
+					v('div', { classes: [ 'bar' ] })
+				);
+			}, AssertionError, 'The value of property "classes" is unexpected.');
 
 			assert.throws(() => {
 				assertRender(
@@ -242,7 +259,7 @@ registerSuite('support/assertRender', {
 					v('div', { classes: [ 'foo', 'bar', 'baz' ] }),
 					v('div', { classes: [ 'foo', 'bar' ] })
 				);
-			});
+			}, AssertionError, 'The value of property "classes" is unexpected.');
 		}
 	},
 
@@ -426,9 +443,26 @@ registerSuite('support/assertRender', {
 			);
 
 			assertRender(
-				w(MockWidget, { classes: null as any }),
+				w(MockWidget, { classes: null }),
 				w(MockWidget, { classes: [] })
 			);
+
+			assertRender(
+				w(MockWidget, { classes: 'foo' }),
+				w(MockWidget, { classes: [ 'foo' ] })
+			);
+
+			assertRender(
+				w(MockWidget, { classes: 'foo' }),
+				w(MockWidget, { classes: 'foo' })
+			);
+
+			assert.throws(() => {
+				assertRender(
+					w(MockWidget, { classes: 'foo' }),
+					w(MockWidget, { classes: [ 'bar' ] })
+				);
+			}, AssertionError, 'The value of property "classes" is unexpected.');
 
 			assert.throws(() => {
 				assertRender(
@@ -442,7 +476,7 @@ registerSuite('support/assertRender', {
 					w(MockWidget, { classes: [ 'foo', 'bar', 'baz' ] }),
 					w(MockWidget, { classes: [ 'foo', 'bar' ] })
 				);
-			});
+			}, AssertionError, 'The value of property "classes" is unexpected.');
 		}
 	},
 

--- a/tests/unit/support/assertRender.ts
+++ b/tests/unit/support/assertRender.ts
@@ -225,12 +225,24 @@ registerSuite('support/assertRender', {
 				v('div',  { classes: [ null,  'bar', 'foo', undefined ] })
 			);
 
+			assertRender(
+				v('div', { classes: null as any }),
+				v('div', { classes: [] })
+			);
+
 			assert.throws(() => {
 				assertRender(
 					v('div', { classes: [ 'foo', null, 'bar' ] }),
 					v('div',  { classes: [ 'foo',  null, 'baz' ] })
 				);
 			}, AssertionError, 'The value of property "classes" is unexpected.');
+
+			assert.throws(() => {
+				assertRender(
+					v('div', { classes: [ 'foo', 'bar', 'baz' ] }),
+					v('div', { classes: [ 'foo', 'bar' ] })
+				);
+			});
 		}
 	},
 
@@ -413,12 +425,24 @@ registerSuite('support/assertRender', {
 				w(MockWidget,  { classes: [ null,  'bar', 'foo', undefined ] })
 			);
 
+			assertRender(
+				w(MockWidget, { classes: null as any }),
+				w(MockWidget, { classes: [] })
+			);
+
 			assert.throws(() => {
 				assertRender(
 					w(MockWidget, { classes: [ 'foo', null, 'bar' ] }),
 					w(MockWidget,  { classes: [ 'foo',  null, 'baz' ] })
 				);
 			}, AssertionError, 'The value of property "classes" is unexpected.');
+
+			assert.throws(() => {
+				assertRender(
+					w(MockWidget, { classes: [ 'foo', 'bar', 'baz' ] }),
+					w(MockWidget, { classes: [ 'foo', 'bar' ] })
+				);
+			});
 		}
 	},
 


### PR DESCRIPTION
**Type:**  feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Uses `compareProperty` to create a custom diff for `classes` on the properties of `DNodes` that ensures only that the actual and expected classes contain equivalent sets of class names. In some cases the order of checks meant that we didn't actually use the custom diff when we should, specifically when the custom diff was on the expected object and the actual object property was an array or object. So this includes a fix for that and tests for it as well.
Resolves #78 
