### PR TITLE
Improve selection utilites

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,22 @@ const expected = v('div', [
 assignChildProperties(expected, '0,2', { classes: css.highlight });
 ```
 
+#### assignChildPropertiesByKey()
+
+Shallowly assigns properties of a `WNode` or `HNode` specified by its key. For example:
+
+```typescript
+const expected = v('div', [
+    v('ol', { type: 'I' }, [
+        v('li', { key: 'a', value: '3' }, [ 'foo' ]),
+        v('li', { }, [ 'bar' ]),
+        v('li', { }, [ 'baz' ])
+    ])
+]);
+
+assignChildPropertiesByKey(expected, 'a', { classes: css.highlight });
+```
+
 #### assignProperties()
 
 Shallowly assigns properties to a `WNode` or `HNode`.  For example:
@@ -528,6 +544,26 @@ replaceChild(expected, '0,0,0', 'qat');
 replaceChild(expected, '0,2', v('span'));
 ```
 
+#### replaceChildByKey()
+
+Replaces a child in a `WNode` or `HNode` with another, specified by a unique key. If more than one child has the same key,
+a warning will be logged but the first node found will be replaced.
+
+An example:
+
+```typescript
+const expected = v('div', [
+    v('ol', { type: 'I' }, [
+        v('li', { key: 'a', value: '3' }, [ 'foo' ]),
+        v('li', { key: 'b' }, [ 'bar' ]),
+        v('li', { }, [ 'baz' ])
+    ])
+]);
+
+replaceChildByKey(expected, 'a', 'qat');
+replaceChildByKey(expected, 'b', v('span'));
+```
+
 #### replaceChildProperties()
 
 Replace a map of properties on a child specified by the index.  The index can be either a number, or a string of numbers
@@ -543,8 +579,29 @@ const expected = v('div', [
     ])
 ]);
 
-assignChildProperties(expected, '0,2', {
+replaceChildProperties(expected, '0,2', {
     classes: css.highlight
+    value: '6'
+});
+```
+
+#### replaceChildPropertiesByKey()
+
+Replace a map of properties on a child specified by the key. Different than `assignChildPropertiesByKey` which *mixes-in* properties, this is a
+wholesale replacement. Since all properties are replaced, the key will be lost if not provided as part of the updated properties. For example:
+
+```typescript
+const expected = v('div', [
+    v('ol', { type: 'I' }, [
+        v('li', { value: '3' }, [ 'foo' ]),
+        v('li', { key: 'b' }, [ 'bar' ]),
+        v('li', { }, [ 'baz' ])
+    ])
+]);
+
+replaceChildPropertiesByKey(expected, 'b', {
+	key: 'b',
+    classes: css.highlight,
     value: '6'
 });
 ```

--- a/src/support/d.ts
+++ b/src/support/d.ts
@@ -4,13 +4,29 @@ import { isHNode, isWNode } from '@dojo/widget-core/d';
 import AssertionError from './AssertionError';
 import { CustomDiff } from './compare';
 
-export function assignChildProperties(target: WNode | HNode, index: number | string, properties: WidgetProperties | VirtualDomProperties): WNode | HNode {
-	const node = findIndex(target, index);
+type FoundNodeInfo<T extends DNode = DNode> = { found?: T, parent?: WNode | HNode | undefined, index?: number };
+
+function  assignChildPropertiesByKeyOrIndex(
+	target: WNode | HNode,
+	keyOrIndex: string | number | object,
+	properties: WidgetProperties | VirtualDomProperties,
+	byKey?: boolean
+) {
+	const { found: node } = findByKeyOrIndex(target, keyOrIndex, byKey);
+
 	if (!node || !(isWNode(node) || isHNode(node))) {
-		throw new TypeError(`Index of "${index}" is not resolving to a valid target`);
+		throw new TypeError(`${(byKey || typeof keyOrIndex === 'object') ? 'Key' : 'Index'} of "${keyOrIndex}" is not resolving to a valid target`);
 	}
 	assignProperties(node, properties);
 	return target;
+}
+
+export function assignChildProperties(target: WNode | HNode, index: number | string, properties: WidgetProperties | VirtualDomProperties): WNode | HNode {
+	return assignChildPropertiesByKeyOrIndex(target, index,  properties);
+}
+
+export function  assignChildPropertiesByKey(target: WNode | HNode,  key: string, properties: WidgetProperties | VirtualDomProperties): WNode | HNode {
+	return assignChildPropertiesByKeyOrIndex(target, key, properties, true);
 }
 
 export function assignProperties(target: HNode, properties: VirtualDomProperties): HNode;
@@ -35,81 +51,106 @@ export function compareProperty<T>(callback: (value: T, name: string, parent: Wi
 	return new CustomDiff(differ);
 }
 
+function replaceChildByKeyOrIndex(
+	target: WNode | HNode,
+	indexOrKey: number | string | object,
+	replacement: DNode,
+	byKey = false
+): WNode | HNode {
+	if (!target.children) {
+		throw new TypeError('Target does not have children.');
+	}
+
+	const { parent, index } = findByKeyOrIndex(target, indexOrKey, byKey);
+
+	if (!parent || typeof index === 'undefined' || !parent.children) {
+		if (byKey || typeof indexOrKey === 'object') {
+			throw new TypeError(`Key of "${indexOrKey}" is not resolving to a valid target`);
+		}
+		else {
+			throw new TypeError(`Index of "${indexOrKey}" is not resolving to a valid target`);
+		}
+	}
+	else {
+		parent.children[index] = replacement;
+	}
+
+	return target;
+}
+
+/**
+ * Finds the child of the target that has the provided key, and replaces it with the provided node.
+ *
+ * *NOTE:* The replacement modifies the passed `target` and does not return a new instance of the `DNode`.
+ * @param target The DNode to replace a child element on
+ * @param key The key of the node to replace
+ * @param replacement The DNode that replaces the found node
+ * @returns {WNode | HNode}
+ */
+export function replaceChildByKey(target: WNode | HNode, key: string | object, replacement: DNode): WNode | HNode {
+	return replaceChildByKeyOrIndex(target, key, replacement, true);
+}
+
 /**
  * Replace a child of DNode.
  *
  * *NOTE:* The replacement modifies the passed `target` and does not return a new instance of the `DNode`.
  * @param target The DNode to replace a child element on
- * @param index A number of the index of a child, or a string with comma separated indexes that would nagivate
+ * @param index A number of the index of a child, or a string with comma separated indexes that would navigate
  * @param replacement The DNode to be replaced
  */
 export function replaceChild(target: WNode | HNode, index: number | string, replacement: DNode): WNode | HNode {
-	/* TODO: [Combine with findIndex](https://github.com/dojo/test-extras/issues/28) */
-	if (!target.children) {
-		throw new TypeError('Target does not have children.');
-	}
-	if (typeof index === 'number') {
-		target.children[index] = replacement;
-	}
-	else {
-		const indexes = index.split(',').map(Number);
-		const lastIndex = indexes.pop()!;
-		const resolvedTarget = indexes.reduce((target, idx) => {
-			if (!(isWNode(target) || isHNode(target)) || !target.children) {
-				throw new TypeError(`Index of "${index}" is not resolving to a valid target`);
-			}
-			return target.children[idx];
-		}, <DNode> target);
-		if (!(isWNode(resolvedTarget) || isHNode(resolvedTarget)) || !resolvedTarget.children) {
-			throw new TypeError(`Index of "${index}" is not resolving to a valid target`);
-		}
-		resolvedTarget.children[lastIndex] = replacement;
-	}
-	return target;
+	return replaceChildByKeyOrIndex(target, index, replacement);
 }
 
-function hasChildren(value: any): value is WNode | HNode {
+function isNode(value: any): value is WNode | HNode {
 	return value && typeof value === 'object' && value !== null;
 }
 
-/**
- * Find a virtual DOM node (`WNode` or `HNode`) based on it having a matching `key` property.
- *
- * The function returns `undefined` if no node was found, otherwise it returns the node.  *NOTE* it will return the first node
- * matching the supplied `key`, but will `console.warn` if more than one node was found.
- */
-export function findKey(target: WNode | HNode, key: string | object): WNode | HNode | undefined {
+function findByKeyOrIndex(target: WNode | HNode, keyOrIndex: string | number | object, byKey = false) {
+	if (byKey || typeof keyOrIndex === 'object') {
+		return findByKey(target,  typeof keyOrIndex === 'number' ? String(keyOrIndex) : keyOrIndex);
+	}
+	else {
+		return findByIndex(target, keyOrIndex);
+	}
+}
+
+function findByKey(
+	target: WNode | HNode,
+	key: string | object,
+	parent?: WNode | HNode,
+	index?: number
+): FoundNodeInfo<WNode | HNode> {
 	if (target.properties.key === key) {
-		return target;
+		return { parent, found: target, index };
 	}
 	if (!target.children) {
-		return undefined;
+		return {};
 	}
-	let found: WNode | HNode | undefined;
+	let found: FoundNodeInfo<WNode | HNode> | undefined;
 	target.children
-		.forEach((child) => {
-			if (hasChildren(child)) {
+		.forEach((child, index) => {
+			if (isNode(child)) {
 				if (found) {
-					if (findKey(child, key)) {
+					if (findByKey(child, key, target, index)) {
 						console.warn(`Duplicate key of "${key}" found.`);
 					}
 				}
 				else {
-					found = findKey(child, key);
+					found = findByKey(child, key, target, index);
 				}
 			}
 		});
-	return found;
+	return found || {};
 }
 
-/**
- * Return a `DNode` that is identified by supplied index
- * @param target The target `WNode` or `HNode` to resolve the index for
- * @param index A number or a string indicating the child index
- */
-export function findIndex(target: WNode | HNode, index: number | string): DNode | undefined {
+function  findByIndex(
+	target: WNode | HNode,
+	index: number | string
+): FoundNodeInfo {
 	if (typeof index === 'number') {
-		return target.children ? target.children[index] : undefined;
+		return target.children  ? { parent: target, found: target.children[index], index } : {};
 	}
 	const indexes = index.split(',').map(Number);
 	const lastIndex = indexes.pop()!;
@@ -120,18 +161,59 @@ export function findIndex(target: WNode | HNode, index: number | string): DNode 
 		return target.children[idx];
 	}, target);
 	if (!(isWNode(resolvedTarget) || isHNode(resolvedTarget)) || !resolvedTarget.children) {
-		return;
+		return {};
 	}
-	return resolvedTarget.children[lastIndex];
+	return { parent: resolvedTarget, found: resolvedTarget.children[lastIndex], index: lastIndex };
+}
+
+/**
+ * Find a virtual DOM node (`WNode` or `HNode`) based on it having a matching `key` property.
+ *
+ * The function returns `undefined` if no node was found, otherwise it returns the node.  *NOTE* it will return the first node
+ * matching the supplied `key`, but will `console.warn` if more than one node was found.
+ */
+export function findKey(target: WNode | HNode, key: string | object): WNode | HNode | undefined {
+	const { found } = findByKey(target, key);
+	return found;
+}
+
+/**
+ * Return a `DNode` that is identified by supplied index
+ * @param target The target `WNode` or `HNode` to resolve the index for
+ * @param index A number or a string indicating the child index
+ */
+export function findIndex(target: WNode | HNode, index: number | string): DNode | undefined {
+	const { found } = findByIndex(target, index);
+	return found;
+}
+
+function replaceChildPropertiesByKeyOrIndex(
+	target: WNode | HNode,
+	indexOrKey: number | string | object,
+	properties: WidgetProperties | VirtualDomProperties,
+	byKey = false
+): WNode | HNode {
+	const { found } = findByKeyOrIndex(target, indexOrKey, byKey);
+
+	if (!found || !(isWNode(found) || isHNode(found))) {
+		if (byKey || typeof indexOrKey === 'object') {
+			throw new TypeError(`Key of "${indexOrKey}" is not resolving to a valid target`);
+		}
+		else {
+			throw new TypeError(`Index of "${indexOrKey}" is not resolving to a valid target`);
+		}
+	}
+
+	replaceProperties(found,  properties);
+	return target;
 }
 
 export function replaceChildProperties(target: WNode | HNode, index: number | string, properties: WidgetProperties | VirtualDomProperties): WNode | HNode {
-	const node = findIndex(target, index);
-	if (!node || !(isWNode(node) || isHNode(node))) {
-		throw new TypeError(`Index of "${index}" is not resolving to a valid target`);
-	}
-	replaceProperties(node, properties);
-	return target;
+	return replaceChildPropertiesByKeyOrIndex(target, index, properties);
+}
+
+export function  replaceChildPropertiesByKey(target: WNode | HNode, key: string | object, properties: WidgetProperties | VirtualDomProperties): WNode | HNode {
+	return replaceChildPropertiesByKeyOrIndex(target, key,  properties, true);
 }
 
 export function replaceProperties(target: HNode, properties: VirtualDomProperties): HNode;

--- a/src/support/d.ts
+++ b/src/support/d.ts
@@ -15,7 +15,7 @@ function  assignChildPropertiesByKeyOrIndex(
 	const { found: node } = findByKeyOrIndex(target, keyOrIndex, byKey);
 
 	if (!node || !(isWNode(node) || isHNode(node))) {
-		const keyOrIndexString = typeof keyOrIndex === 'string' ? keyOrIndex : JSON.stringify(keyOrIndex);
+		const keyOrIndexString = typeof keyOrIndex === 'object' ? JSON.stringify(keyOrIndex) : keyOrIndex;
 		throw new TypeError(`${(byKey || typeof keyOrIndex === 'object') ? 'Key' : 'Index'} of "${keyOrIndexString}" is not resolving to a valid target`);
 	}
 	assignProperties(node, properties);
@@ -66,7 +66,7 @@ function replaceChildByKeyOrIndex(
 
 	if (!parent || typeof index === 'undefined' || !parent.children) {
 		if (byKey || typeof indexOrKey === 'object') {
-			throw new TypeError(`Key of "${typeof indexOrKey === 'string' ? indexOrKey : JSON.stringify(indexOrKey)}" is not resolving to a valid target`);
+			throw new TypeError(`Key of "${typeof indexOrKey === 'object' ? JSON.stringify(indexOrKey) : indexOrKey}" is not resolving to a valid target`);
 		}
 		else {
 			throw new TypeError(`Index of "${indexOrKey}" is not resolving to a valid target`);
@@ -110,7 +110,7 @@ function isNode(value: any): value is WNode | HNode {
 
 function findByKeyOrIndex(target: WNode | HNode, keyOrIndex: string | number | object, byKey = false) {
 	if (byKey || typeof keyOrIndex === 'object') {
-		return findByKey(target,  typeof keyOrIndex === 'number' ? String(keyOrIndex) : keyOrIndex);
+		return findByKey(target,  keyOrIndex);
 	}
 	else {
 		return findByIndex(target, keyOrIndex);
@@ -119,7 +119,7 @@ function findByKeyOrIndex(target: WNode | HNode, keyOrIndex: string | number | o
 
 function findByKey(
 	target: WNode | HNode,
-	key: string | object,
+	key: string | object | number,
 	parent?: WNode | HNode,
 	index?: number
 ): FoundNodeInfo<WNode | HNode> {
@@ -135,7 +135,7 @@ function findByKey(
 			if (isNode(child)) {
 				if (found) {
 					if (findByKey(child, key, target, index).found) {
-						console.warn(`Duplicate key of "${typeof key === 'string' ? key : JSON.stringify(key)}" found.`);
+						console.warn(`Duplicate key of "${typeof key === 'object' ? JSON.stringify(key) : key }" found.`);
 					}
 				}
 				else {
@@ -198,7 +198,7 @@ function replaceChildPropertiesByKeyOrIndex(
 
 	if (!found || !(isWNode(found) || isHNode(found))) {
 		if (byKey || typeof indexOrKey === 'object') {
-			throw new TypeError(`Key of "${typeof indexOrKey === 'string' ? indexOrKey : JSON.stringify(indexOrKey)}" is not resolving to a valid target`);
+			throw new TypeError(`Key of "${typeof indexOrKey === 'object' ? JSON.stringify(indexOrKey) : indexOrKey}" is not resolving to a valid target`);
 		}
 		else {
 			throw new TypeError(`Index of "${indexOrKey}" is not resolving to a valid target`);

--- a/src/support/d.ts
+++ b/src/support/d.ts
@@ -15,7 +15,8 @@ function  assignChildPropertiesByKeyOrIndex(
 	const { found: node } = findByKeyOrIndex(target, keyOrIndex, byKey);
 
 	if (!node || !(isWNode(node) || isHNode(node))) {
-		throw new TypeError(`${(byKey || typeof keyOrIndex === 'object') ? 'Key' : 'Index'} of "${keyOrIndex}" is not resolving to a valid target`);
+		const keyOrIndexString = typeof keyOrIndex === 'string' ? keyOrIndex : JSON.stringify(keyOrIndex);
+		throw new TypeError(`${(byKey || typeof keyOrIndex === 'object') ? 'Key' : 'Index'} of "${keyOrIndexString}" is not resolving to a valid target`);
 	}
 	assignProperties(node, properties);
 	return target;
@@ -25,7 +26,7 @@ export function assignChildProperties(target: WNode | HNode, index: number | str
 	return assignChildPropertiesByKeyOrIndex(target, index,  properties);
 }
 
-export function  assignChildPropertiesByKey(target: WNode | HNode,  key: string, properties: WidgetProperties | VirtualDomProperties): WNode | HNode {
+export function  assignChildPropertiesByKey(target: WNode | HNode,  key: string | object, properties: WidgetProperties | VirtualDomProperties): WNode | HNode {
 	return assignChildPropertiesByKeyOrIndex(target, key, properties, true);
 }
 
@@ -65,7 +66,7 @@ function replaceChildByKeyOrIndex(
 
 	if (!parent || typeof index === 'undefined' || !parent.children) {
 		if (byKey || typeof indexOrKey === 'object') {
-			throw new TypeError(`Key of "${indexOrKey}" is not resolving to a valid target`);
+			throw new TypeError(`Key of "${typeof indexOrKey === 'string' ? indexOrKey : JSON.stringify(indexOrKey)}" is not resolving to a valid target`);
 		}
 		else {
 			throw new TypeError(`Index of "${indexOrKey}" is not resolving to a valid target`);
@@ -133,8 +134,8 @@ function findByKey(
 		.forEach((child, index) => {
 			if (isNode(child)) {
 				if (found) {
-					if (findByKey(child, key, target, index)) {
-						console.warn(`Duplicate key of "${key}" found.`);
+					if (findByKey(child, key, target, index).found) {
+						console.warn(`Duplicate key of "${typeof key === 'string' ? key : JSON.stringify(key)}" found.`);
 					}
 				}
 				else {
@@ -197,7 +198,7 @@ function replaceChildPropertiesByKeyOrIndex(
 
 	if (!found || !(isWNode(found) || isHNode(found))) {
 		if (byKey || typeof indexOrKey === 'object') {
-			throw new TypeError(`Key of "${indexOrKey}" is not resolving to a valid target`);
+			throw new TypeError(`Key of "${typeof indexOrKey === 'string' ? indexOrKey : JSON.stringify(indexOrKey)}" is not resolving to a valid target`);
 		}
 		else {
 			throw new TypeError(`Index of "${indexOrKey}" is not resolving to a valid target`);

--- a/tests/unit/support/d.ts
+++ b/tests/unit/support/d.ts
@@ -4,12 +4,15 @@ const { assert } = intern.getPlugin('chai');
 import { stub } from 'sinon';
 import {
 	assignChildProperties,
+	assignChildPropertiesByKey,
 	assignProperties,
 	compareProperty,
 	findIndex,
 	findKey,
 	replaceChild,
+	replaceChildByKey,
 	replaceChildProperties,
+	replaceChildPropertiesByKey,
 	replaceProperties
 } from '../../../src/support/d';
 
@@ -36,6 +39,57 @@ registerSuite('support/virtualDom', {
 			assert.throws(() => {
 				assignChildProperties(actual, 0, { target: '_blank' });
 			}, TypeError, 'Index of "0" is not resolving to a valid target');
+		}
+	},
+
+	'assignChildPropertiesByKey()': {
+		'by string key'() {
+			const actual = v('div', { key: 'a' }, [ null, v('a', { key: 'b', href: '#link' }) ]);
+
+			assertRender(actual, v('div', { key: 'a' }, [ null, v('a', { key: 'b', href: '#link' }) ]));
+
+			assignChildPropertiesByKey(actual, 'b', { target: '_blank' });
+
+			assertRender(actual, v('div', { key: 'a' }, [ null, v('a', { key: 'b', href: '#link', target: '_blank' }) ]));
+		},
+
+		'by object key'() {
+			const key = {};
+			const actual = v('div', { key: 'a' }, [ null, v('a', { key, href: '#link' }) ]);
+
+			assertRender(actual, v('div', { key: 'a' }, [ null, v('a', { key, href: '#link' }) ]));
+
+			assignChildPropertiesByKey(actual, key, { target: '_blank' });
+
+			assertRender(actual, v('div', { key: 'a' }, [ null, v('a', { key, href: '#link', target: '_blank' }) ]));
+		},
+
+		'does not resolve - string'() {
+			const actual = v('div', {}, [ v('a', { href: '#link' }) ]);
+
+			assert.throws(() => {
+				assignChildPropertiesByKey(actual, 'a', { target: '_blank' });
+			}, TypeError, 'Key of "a" is not resolving to a valid target');
+		},
+
+		'does not resolve - object'() {
+			const actual = v('div', {}, [ v('a', { href: '#link' }) ]);
+
+			assert.throws(() => {
+				assignChildPropertiesByKey(actual, {}, { target: '_blank' });
+			}, TypeError, 'Key of "{}" is not resolving to a valid target');
+		},
+
+		'duplicate key'() {
+			const actual = v('div', {}, [ v('a', { key: 'a' }), v('a', { key: 'a', href: '#link' }) ]);
+			const warnStub = stub(console, 'warn');
+
+			assignChildPropertiesByKey(actual, 'a', { target: '_blank' });
+			warnStub.restore();
+
+			assertRender(actual,  v('div', {}, [ v('a', { target: '_blank', key: 'a' }), v('a', { key: 'a', href: '#link' }) ]));
+			assert.isTrue(warnStub.calledOnce);
+			assert.deepEqual(warnStub.args, [ [ 'Duplicate key of "a" found.' ] ]);
 		}
 	},
 
@@ -155,6 +209,74 @@ registerSuite('support/virtualDom', {
 		}
 	},
 
+	'replaceChildByKey()': {
+		'by key'() {
+			const actual = v('div', { key: 'a' }, [ null, v('a', { key: 'b', href: '#link' }) ]);
+
+			assertRender(actual, v('div', { key: 'a' }, [ null, v('a', { key: 'b', href: '#link' }) ]));
+
+			replaceChildByKey(actual, 'b', v('dfn'));
+
+			assertRender(actual, v('div', { key: 'a' }, [ null, v('dfn') ]), 'Didnt render correct vdom');
+		},
+
+		'by object key'() {
+			const key = {};
+			const actual = v('div', { key: 'a' }, [ null, v('a', { key, href: '#link' }) ]);
+
+			assertRender(actual, v('div', { key: 'a' }, [ null, v('a', { key, href: '#link' }) ]));
+
+			replaceChildByKey(actual, key, v('dfn'));
+
+			assertRender(actual, v('div', { key: 'a' }, [ null,  v('dfn') ]));
+		},
+
+		'nested child'() {
+			const actual = v('div', { key: 'a' }, [ v('div', {}, [ v('div', { key: 'b' }) ]), v('a', { href: '#link' }) ]);
+
+			assertRender(actual, v('div', { key: 'a' }, [ v('div', {}, [ v('div', { key: 'b' }) ]), v('a', { href: '#link' }) ]));
+
+			replaceChildByKey(actual, 'b', 'baz');
+
+			assertRender(actual, v('div', { key: 'a' }, [ v('div', {}, [ 'baz' ]), v('a', { href: '#link' }) ]));
+		},
+
+		'duplicate key'() {
+			const actual = v('div', {}, [ v('a', { key: 'a' }), v('a', { key: 'a', href: '#link' }) ]);
+			const warnStub = stub(console, 'warn');
+
+			replaceChildByKey(actual, 'a', 'foo');
+			warnStub.restore();
+			assertRender(actual, v('div', {}, [ 'foo', v('a', { key: 'a', href: '#link' }) ]));
+			assert.isTrue(warnStub.calledOnce);
+			assert.isTrue(warnStub.calledWith('Duplicate key of "a" found.'));
+		},
+
+		'string key resolving to a non child node throws'() {
+			const actual = v('div', {}, [ v('span', {}, [ 'foobar' ]), v('a', { href: '#link' }) ]);
+
+			assert.throws(() => {
+				replaceChildByKey(actual, 'a', 'bar');
+			}, TypeError, 'Key of "a" is not resolving to a valid target');
+		},
+
+		'object key resolve to a non child node throws'() {
+			const actual = v('div', {}, [ v('span', {}, [ 'foobar' ]), v('a', { href: '#link' }) ]);
+
+			assert.throws(() => {
+				replaceChildByKey(actual, {}, 'bar');
+			}, TypeError, 'Key of "{}" is not resolving to a valid target');
+		},
+
+		'no children - should throw'() {
+			const actual = v('div', {});
+
+			assert.throws(() => {
+				replaceChildByKey(actual, 'key', 'foo');
+			}, TypeError, 'Target does not have children.');
+		}
+	},
+
 	'replaceChildProperties()': {
 		'by index'() {
 			const actual = v('div', {}, [ null, v('a', { href: '#link' }) ]);
@@ -175,6 +297,57 @@ registerSuite('support/virtualDom', {
 				replaceChildProperties(actual, 0, { target: '_blank' });
 			}, TypeError, 'Index of "0" is not resolving to a valid target');
 		}
+	},
+
+	'replaceChildPropertiesByKey()': {
+		'by string key'() {
+			const actual = v('div', { key: 'a' }, [ null, v('a', { key: 'b', href: '#link' }) ]);
+
+			assertRender(actual, v('div', { key: 'a' }, [ null, v('a', { key: 'b', href: '#link' }) ]));
+
+			replaceChildPropertiesByKey(actual, 'b', { key: 'b', target: '_blank' });
+
+			assertRender(actual, v('div', { key: 'a' }, [ null, v('a', { key: 'b', target: '_blank' }) ]));
+		},
+
+		'by object key'() {
+			const key = {};
+			const actual = v('div', { key: 'a' }, [ null, v('a', { key, href: '#link' }) ]);
+
+			assertRender(actual, v('div', { key: 'a' }, [ null, v('a', { key, href: '#link' }) ]));
+
+			replaceChildPropertiesByKey(actual, key, { key, target: '_blank' });
+
+			assertRender(actual, v('div', { key: 'a' }, [ null, v('a', { key, target: '_blank' }) ]));
+		},
+
+		'duplicate key'() {
+			const actual = v('div', {}, [ v('a', { key: 'a' }), v('a', { key: 'a', href: '#link' }) ]);
+			const warnStub = stub(console, 'warn');
+
+			replaceChildPropertiesByKey(actual, 'a', { key: 'a', prop: 'b' });
+			warnStub.restore();
+			assertRender(actual, v('div', {}, [ v('a', { key: 'a', prop: 'b' }), v('a', { key: 'a', href: '#link' }) ]));
+			assert.isTrue(warnStub.calledOnce);
+			assert.isTrue(warnStub.calledWith('Duplicate key of "a" found.'));
+		},
+
+		'string key resolving to a non child node throws'() {
+			const actual = v('div', {}, [ v('span', {}, [ 'foobar' ]), v('a', { href: '#link' }) ]);
+
+			assert.throws(() => {
+				replaceChildPropertiesByKey(actual, 'a', {});
+			}, TypeError, 'Key of "a" is not resolving to a valid target');
+		},
+
+		'object key resolve to a non child node throws'() {
+			const actual = v('div', {}, [ v('span', {}, [ 'foobar' ]), v('a', { href: '#link' }) ]);
+
+			assert.throws(() => {
+				replaceChildPropertiesByKey(actual, {}, {});
+			}, TypeError, 'Key of "{}" is not resolving to a valid target');
+		}
+
 	},
 
 	'replaceProperties()': {
@@ -222,7 +395,7 @@ registerSuite('support/virtualDom', {
 			assertRender(findKey(vnode, 'foo')!, w<any>('sub-widget', { key: 'foo', onClick() { } }), 'should find widget');
 		},
 
-		'duplicate keys warn'() {
+		'duplicate string keys warn'() {
 			const warnStub = stub(console, 'warn');
 
 			const fixture = v('div', { key: 'foo' }, [
@@ -237,6 +410,26 @@ registerSuite('support/virtualDom', {
 			assertRender(findKey(fixture, 'icon')!, v('i', { key: 'icon', id: 'i1' }), 'should find first key');
 			assert.strictEqual(warnStub.callCount, 1, 'should have been called once');
 			assert.strictEqual(warnStub.lastCall.args[0], 'Duplicate key of "icon" found.', 'should have logged duplicate key');
+			warnStub.restore();
+		},
+
+
+		'duplicate object keys warn'() {
+			const warnStub = stub(console, 'warn');
+			const key = {};
+
+			const fixture = v('div', { key: 'foo' }, [
+				v('span', { key: 'parent1' }, [
+					v('i', { key, id: 'i1' })
+				]),
+				v('span', { key: 'parent2' }, [
+					v('i', { key, id: 'i2' })
+				])
+			]);
+
+			assertRender(findKey(fixture, key)!, v('i', { key, id: 'i1' }), 'should find first key');
+			assert.strictEqual(warnStub.callCount, 1, 'should have been called once');
+			assert.strictEqual(warnStub.lastCall.args[0], 'Duplicate key of "{}" found.', 'should have logged duplicate key');
 			warnStub.restore();
 		}
 	},

--- a/tests/unit/support/d.ts
+++ b/tests/unit/support/d.ts
@@ -413,7 +413,6 @@ registerSuite('support/virtualDom', {
 			warnStub.restore();
 		},
 
-
 		'duplicate object keys warn'() {
 			const warnStub = stub(console, 'warn');
 			const key = {};

--- a/tests/unit/support/d.ts
+++ b/tests/unit/support/d.ts
@@ -440,8 +440,8 @@ registerSuite('support/virtualDom', {
 		},
 
 		'no children returns undefined'() {
-			const actual = w('widget', {});
-			assert.isUndefined(findIndex(actual, 0));
+			assert.isUndefined(findIndex(v('div', {}), 0));
+			assert.isUndefined(findIndex(w('widget', {}), 0));
 		},
 
 		'by string deep index'() {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Adds `replaceChildByKey`, `replaceChildPropertiesByKey`, and `assignChildPropertyByKey` functions to `support/d.ts`. This also refactors some of the logic in `support/d.ts` to reuse the same logic for finding nodes in multiple places.
Resolves #9, #28 
