### PR TITLE
Revert "Add `byKey` versions of vdom selection utilities (#82)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,22 +422,6 @@ const expected = v('div', [
 assignChildProperties(expected, '0,2', { classes: css.highlight });
 ```
 
-#### assignChildPropertiesByKey()
-
-Shallowly assigns properties of a `WNode` or `HNode` specified by its key. For example:
-
-```typescript
-const expected = v('div', [
-    v('ol', { type: 'I' }, [
-        v('li', { key: 'a', value: '3' }, [ 'foo' ]),
-        v('li', { }, [ 'bar' ]),
-        v('li', { }, [ 'baz' ])
-    ])
-]);
-
-assignChildPropertiesByKey(expected, 'a', { classes: css.highlight });
-```
-
 #### assignProperties()
 
 Shallowly assigns properties to a `WNode` or `HNode`.  For example:
@@ -544,26 +528,6 @@ replaceChild(expected, '0,0,0', 'qat');
 replaceChild(expected, '0,2', v('span'));
 ```
 
-#### replaceChildByKey()
-
-Replaces a child in a `WNode` or `HNode` with another, specified by a unique key. If more than one child has the same key,
-a warning will be logged but the first node found will be replaced.
-
-An example:
-
-```typescript
-const expected = v('div', [
-    v('ol', { type: 'I' }, [
-        v('li', { key: 'a', value: '3' }, [ 'foo' ]),
-        v('li', { key: 'b' }, [ 'bar' ]),
-        v('li', { }, [ 'baz' ])
-    ])
-]);
-
-replaceChildByKey(expected, 'a', 'qat');
-replaceChildByKey(expected, 'b', v('span'));
-```
-
 #### replaceChildProperties()
 
 Replace a map of properties on a child specified by the index.  The index can be either a number, or a string of numbers
@@ -579,29 +543,8 @@ const expected = v('div', [
     ])
 ]);
 
-replaceChildProperties(expected, '0,2', {
+assignChildProperties(expected, '0,2', {
     classes: css.highlight
-    value: '6'
-});
-```
-
-#### replaceChildPropertiesByKey()
-
-Replace a map of properties on a child specified by the key. Different than `assignChildPropertiesByKey` which *mixes-in* properties, this is a
-wholesale replacement. Since all properties are replaced, the key will be lost if not provided as part of the updated properties. For example:
-
-```typescript
-const expected = v('div', [
-    v('ol', { type: 'I' }, [
-        v('li', { value: '3' }, [ 'foo' ]),
-        v('li', { key: 'b' }, [ 'bar' ]),
-        v('li', { }, [ 'baz' ])
-    ])
-]);
-
-replaceChildPropertiesByKey(expected, 'b', {
-	key: 'b',
-    classes: css.highlight,
     value: '6'
 });
 ```

--- a/tests/unit/support/d.ts
+++ b/tests/unit/support/d.ts
@@ -4,15 +4,12 @@ const { assert } = intern.getPlugin('chai');
 import { stub } from 'sinon';
 import {
 	assignChildProperties,
-	assignChildPropertiesByKey,
 	assignProperties,
 	compareProperty,
 	findIndex,
 	findKey,
 	replaceChild,
-	replaceChildByKey,
 	replaceChildProperties,
-	replaceChildPropertiesByKey,
 	replaceProperties
 } from '../../../src/support/d';
 
@@ -39,57 +36,6 @@ registerSuite('support/virtualDom', {
 			assert.throws(() => {
 				assignChildProperties(actual, 0, { target: '_blank' });
 			}, TypeError, 'Index of "0" is not resolving to a valid target');
-		}
-	},
-
-	'assignChildPropertiesByKey()': {
-		'by string key'() {
-			const actual = v('div', { key: 'a' }, [ null, v('a', { key: 'b', href: '#link' }) ]);
-
-			assertRender(actual, v('div', { key: 'a' }, [ null, v('a', { key: 'b', href: '#link' }) ]));
-
-			assignChildPropertiesByKey(actual, 'b', { target: '_blank' });
-
-			assertRender(actual, v('div', { key: 'a' }, [ null, v('a', { key: 'b', href: '#link', target: '_blank' }) ]));
-		},
-
-		'by object key'() {
-			const key = {};
-			const actual = v('div', { key: 'a' }, [ null, v('a', { key, href: '#link' }) ]);
-
-			assertRender(actual, v('div', { key: 'a' }, [ null, v('a', { key, href: '#link' }) ]));
-
-			assignChildPropertiesByKey(actual, key, { target: '_blank' });
-
-			assertRender(actual, v('div', { key: 'a' }, [ null, v('a', { key, href: '#link', target: '_blank' }) ]));
-		},
-
-		'does not resolve - string'() {
-			const actual = v('div', {}, [ v('a', { href: '#link' }) ]);
-
-			assert.throws(() => {
-				assignChildPropertiesByKey(actual, 'a', { target: '_blank' });
-			}, TypeError, 'Key of "a" is not resolving to a valid target');
-		},
-
-		'does not resolve - object'() {
-			const actual = v('div', {}, [ v('a', { href: '#link' }) ]);
-
-			assert.throws(() => {
-				assignChildPropertiesByKey(actual, {}, { target: '_blank' });
-			}, TypeError, 'Key of "{}" is not resolving to a valid target');
-		},
-
-		'duplicate key'() {
-			const actual = v('div', {}, [ v('a', { key: 'a' }), v('a', { key: 'a', href: '#link' }) ]);
-			const warnStub = stub(console, 'warn');
-
-			assignChildPropertiesByKey(actual, 'a', { target: '_blank' });
-			warnStub.restore();
-
-			assertRender(actual,  v('div', {}, [ v('a', { target: '_blank', key: 'a' }), v('a', { key: 'a', href: '#link' }) ]));
-			assert.isTrue(warnStub.calledOnce);
-			assert.deepEqual(warnStub.args, [ [ 'Duplicate key of "a" found.' ] ]);
 		}
 	},
 
@@ -209,74 +155,6 @@ registerSuite('support/virtualDom', {
 		}
 	},
 
-	'replaceChildByKey()': {
-		'by key'() {
-			const actual = v('div', { key: 'a' }, [ null, v('a', { key: 'b', href: '#link' }) ]);
-
-			assertRender(actual, v('div', { key: 'a' }, [ null, v('a', { key: 'b', href: '#link' }) ]));
-
-			replaceChildByKey(actual, 'b', v('dfn'));
-
-			assertRender(actual, v('div', { key: 'a' }, [ null, v('dfn') ]), 'Didnt render correct vdom');
-		},
-
-		'by object key'() {
-			const key = {};
-			const actual = v('div', { key: 'a' }, [ null, v('a', { key, href: '#link' }) ]);
-
-			assertRender(actual, v('div', { key: 'a' }, [ null, v('a', { key, href: '#link' }) ]));
-
-			replaceChildByKey(actual, key, v('dfn'));
-
-			assertRender(actual, v('div', { key: 'a' }, [ null,  v('dfn') ]));
-		},
-
-		'nested child'() {
-			const actual = v('div', { key: 'a' }, [ v('div', {}, [ v('div', { key: 'b' }) ]), v('a', { href: '#link' }) ]);
-
-			assertRender(actual, v('div', { key: 'a' }, [ v('div', {}, [ v('div', { key: 'b' }) ]), v('a', { href: '#link' }) ]));
-
-			replaceChildByKey(actual, 'b', 'baz');
-
-			assertRender(actual, v('div', { key: 'a' }, [ v('div', {}, [ 'baz' ]), v('a', { href: '#link' }) ]));
-		},
-
-		'duplicate key'() {
-			const actual = v('div', {}, [ v('a', { key: 'a' }), v('a', { key: 'a', href: '#link' }) ]);
-			const warnStub = stub(console, 'warn');
-
-			replaceChildByKey(actual, 'a', 'foo');
-			warnStub.restore();
-			assertRender(actual, v('div', {}, [ 'foo', v('a', { key: 'a', href: '#link' }) ]));
-			assert.isTrue(warnStub.calledOnce);
-			assert.isTrue(warnStub.calledWith('Duplicate key of "a" found.'));
-		},
-
-		'string key resolving to a non child node throws'() {
-			const actual = v('div', {}, [ v('span', {}, [ 'foobar' ]), v('a', { href: '#link' }) ]);
-
-			assert.throws(() => {
-				replaceChildByKey(actual, 'a', 'bar');
-			}, TypeError, 'Key of "a" is not resolving to a valid target');
-		},
-
-		'object key resolve to a non child node throws'() {
-			const actual = v('div', {}, [ v('span', {}, [ 'foobar' ]), v('a', { href: '#link' }) ]);
-
-			assert.throws(() => {
-				replaceChildByKey(actual, {}, 'bar');
-			}, TypeError, 'Key of "{}" is not resolving to a valid target');
-		},
-
-		'no children - should throw'() {
-			const actual = v('div', {});
-
-			assert.throws(() => {
-				replaceChildByKey(actual, 'key', 'foo');
-			}, TypeError, 'Target does not have children.');
-		}
-	},
-
 	'replaceChildProperties()': {
 		'by index'() {
 			const actual = v('div', {}, [ null, v('a', { href: '#link' }) ]);
@@ -297,57 +175,6 @@ registerSuite('support/virtualDom', {
 				replaceChildProperties(actual, 0, { target: '_blank' });
 			}, TypeError, 'Index of "0" is not resolving to a valid target');
 		}
-	},
-
-	'replaceChildPropertiesByKey()': {
-		'by string key'() {
-			const actual = v('div', { key: 'a' }, [ null, v('a', { key: 'b', href: '#link' }) ]);
-
-			assertRender(actual, v('div', { key: 'a' }, [ null, v('a', { key: 'b', href: '#link' }) ]));
-
-			replaceChildPropertiesByKey(actual, 'b', { key: 'b', target: '_blank' });
-
-			assertRender(actual, v('div', { key: 'a' }, [ null, v('a', { key: 'b', target: '_blank' }) ]));
-		},
-
-		'by object key'() {
-			const key = {};
-			const actual = v('div', { key: 'a' }, [ null, v('a', { key, href: '#link' }) ]);
-
-			assertRender(actual, v('div', { key: 'a' }, [ null, v('a', { key, href: '#link' }) ]));
-
-			replaceChildPropertiesByKey(actual, key, { key, target: '_blank' });
-
-			assertRender(actual, v('div', { key: 'a' }, [ null, v('a', { key, target: '_blank' }) ]));
-		},
-
-		'duplicate key'() {
-			const actual = v('div', {}, [ v('a', { key: 'a' }), v('a', { key: 'a', href: '#link' }) ]);
-			const warnStub = stub(console, 'warn');
-
-			replaceChildPropertiesByKey(actual, 'a', { key: 'a', prop: 'b' });
-			warnStub.restore();
-			assertRender(actual, v('div', {}, [ v('a', { key: 'a', prop: 'b' }), v('a', { key: 'a', href: '#link' }) ]));
-			assert.isTrue(warnStub.calledOnce);
-			assert.isTrue(warnStub.calledWith('Duplicate key of "a" found.'));
-		},
-
-		'string key resolving to a non child node throws'() {
-			const actual = v('div', {}, [ v('span', {}, [ 'foobar' ]), v('a', { href: '#link' }) ]);
-
-			assert.throws(() => {
-				replaceChildPropertiesByKey(actual, 'a', {});
-			}, TypeError, 'Key of "a" is not resolving to a valid target');
-		},
-
-		'object key resolve to a non child node throws'() {
-			const actual = v('div', {}, [ v('span', {}, [ 'foobar' ]), v('a', { href: '#link' }) ]);
-
-			assert.throws(() => {
-				replaceChildPropertiesByKey(actual, {}, {});
-			}, TypeError, 'Key of "{}" is not resolving to a valid target');
-		}
-
 	},
 
 	'replaceProperties()': {
@@ -395,7 +222,7 @@ registerSuite('support/virtualDom', {
 			assertRender(findKey(vnode, 'foo')!, w<any>('sub-widget', { key: 'foo', onClick() { } }), 'should find widget');
 		},
 
-		'duplicate string keys warn'() {
+		'duplicate keys warn'() {
 			const warnStub = stub(console, 'warn');
 
 			const fixture = v('div', { key: 'foo' }, [
@@ -411,25 +238,6 @@ registerSuite('support/virtualDom', {
 			assert.strictEqual(warnStub.callCount, 1, 'should have been called once');
 			assert.strictEqual(warnStub.lastCall.args[0], 'Duplicate key of "icon" found.', 'should have logged duplicate key');
 			warnStub.restore();
-		},
-
-		'duplicate object keys warn'() {
-			const warnStub = stub(console, 'warn');
-			const key = {};
-
-			const fixture = v('div', { key: 'foo' }, [
-				v('span', { key: 'parent1' }, [
-					v('i', { key, id: 'i1' })
-				]),
-				v('span', { key: 'parent2' }, [
-					v('i', { key, id: 'i2' })
-				])
-			]);
-
-			assertRender(findKey(fixture, key)!, v('i', { key, id: 'i1' }), 'should find first key');
-			assert.strictEqual(warnStub.callCount, 1, 'should have been called once');
-			assert.strictEqual(warnStub.lastCall.args[0], 'Duplicate key of "{}" found.', 'should have logged duplicate key');
-			warnStub.restore();
 		}
 	},
 
@@ -440,8 +248,8 @@ registerSuite('support/virtualDom', {
 		},
 
 		'no children returns undefined'() {
-			assert.isUndefined(findIndex(v('div', {}), 0));
-			assert.isUndefined(findIndex(w('widget', {}), 0));
+			const actual = w('widget', {});
+			assert.isUndefined(findIndex(actual, 0));
 		},
 
 		'by string deep index'() {


### PR DESCRIPTION
This reverts commit 77e80ac59f665bab44cccd035b6db4e28686ac26.

**Type:** bug
The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
This change broke tests in widgets
