### PR TITLE
Move createResolvers() from widget-core to test-extras.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojo/test-extras",
-  "version": "0.3.1-pre",
+  "version": "0.3.1-rc.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/harness.ts
+++ b/src/harness.ts
@@ -254,7 +254,6 @@ export class Harness<W extends WidgetBase<WidgetProperties>> extends Evented {
 		if (this._children) {
 			this._widgetHarness.setChildren(this._children);
 			this._children = undefined;
-
 		}
 		if (!this._projectorHandle) {
 			this._widgetHarness.async = false;

--- a/src/harness.ts
+++ b/src/harness.ts
@@ -254,6 +254,7 @@ export class Harness<W extends WidgetBase<WidgetProperties>> extends Evented {
 		if (this._children) {
 			this._widgetHarness.setChildren(this._children);
 			this._children = undefined;
+
 		}
 		if (!this._projectorHandle) {
 			this._widgetHarness.async = false;

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -1,0 +1,47 @@
+import global from '@dojo/shim/global';
+import { stub, SinonStub } from 'sinon';
+
+export interface Resolvers {
+	stub(): void;
+	resolve(): void;
+	restore(): void;
+}
+
+export function createResolvers() {
+	let rAFStub: SinonStub;
+	let rICStub: SinonStub;
+
+	function resolveRAF() {
+		for (let i = 0; i < rAFStub.callCount; i++) {
+			rAFStub.getCall(i).args[0]();
+		}
+		rAFStub.reset();
+	}
+
+	function resolveRIC() {
+		for (let i = 0; i < rICStub.callCount; i++) {
+			rICStub.getCall(i).args[0]();
+		}
+		rICStub.reset();
+	}
+
+	return {
+		resolve() {
+			resolveRAF();
+			resolveRIC();
+		},
+		stub() {
+			rAFStub = stub(global, 'requestAnimationFrame').returns(1);
+			if (global.requestIdleCallback) {
+				rICStub = stub(global, 'requestIdleCallback').returns(1);
+			}
+			else {
+				rICStub = stub(global, 'setTimeout').returns(1);
+			}
+		},
+		restore() {
+			rAFStub.restore();
+			rICStub.restore();
+		}
+	};
+}

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -4,4 +4,5 @@ import '../../src/support/loadJsdom';
 /* Modules to test */
 import './harness';
 import './main';
+import './resolvers';
 import './support/all';

--- a/tests/unit/resolvers.ts
+++ b/tests/unit/resolvers.ts
@@ -1,0 +1,74 @@
+const { registerSuite } = intern.getInterface('object');
+const { assert } = intern.getPlugin('chai');
+import { stub } from 'sinon';
+
+import global from '@dojo/shim/global';
+import { createResolvers, Resolvers } from '../../src/resolvers';
+
+let resolvers: Resolvers;
+
+registerSuite('resolvers', {
+	beforeEach() {
+		resolvers = createResolvers();
+	},
+
+	afterEach() {
+		resolvers && resolvers.restore();
+	},
+
+	tests: {
+		'stub and restore'() {
+			// Verify the global functions are not stubs.
+			assert.isTrue(global.requestAnimationFrame.id == null);
+			assert.isTrue((global.requestIdleCallback || global.setTimeout).id == null);
+
+			resolvers.stub();
+			// Verify the global functions are stubs.
+			assert.isTrue(global.requestAnimationFrame.id != null);
+			assert.isTrue((global.requestIdleCallback || global.setTimeout).id != null);
+
+			resolvers.restore();
+			// Verify the global functions are not stubs.
+			assert.isTrue(global.requestAnimationFrame.id == null);
+			assert.isTrue((global.requestIdleCallback || global.setTimeout).id == null);
+		},
+
+		'resolve requestAnimationFrame'() {
+			const callback = stub();
+
+			resolvers.stub();
+
+			requestAnimationFrame(callback);
+			assert.isFalse(callback.called);
+
+			resolvers.resolve();
+			assert.isTrue(callback.calledOnce);
+
+			resolvers.restore();
+
+			const dfd = this.async();
+			setTimeout(dfd.callback(() => {
+				assert.isTrue(callback.calledOnce);
+			}), 100);
+		},
+
+		'resolve idle callback'() {
+			const callback = stub();
+
+			resolvers.stub();
+
+			(global.requestIdleCallback || global.setTimeout)(callback);
+			assert.isFalse(callback.called);
+
+			resolvers.resolve();
+			assert.isTrue(callback.calledOnce);
+
+			resolvers.restore();
+
+			const dfd = this.async();
+			setTimeout(dfd.callback(() => {
+				assert.isTrue(callback.calledOnce);
+			}), 100);
+		}
+	}
+});


### PR DESCRIPTION
I ~~moved~~copied createResolvers() from widget-core to test-extras so it can be more widely used.

Fixes #76 