### PR TITLE
Intern plugins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojo/test-extras",
-  "version": "0.5.0",
+  "version": "0.5.1-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -320,6 +320,12 @@
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
       "dev": true
     },
+    "@types/mockery": {
+      "version": "1.4.29",
+      "resolved": "https://registry.npmjs.org/@types/mockery/-/mockery-1.4.29.tgz",
+      "integrity": "sha1-m6It838H43gP/4Ux0aOOYz+UV6U=",
+      "dev": true
+    },
     "@types/node": {
       "version": "9.4.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.0.tgz",
@@ -383,6 +389,16 @@
       "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-1.2.28.tgz",
       "integrity": "sha1-zF8Z0haUFtVWzcoFtZsp5F+kl+I=",
       "dev": true
+    },
+    "@types/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-FKjsOVbC6B7bdSB5CuzyHCkK69I="
+    },
+    "@types/strip-json-comments": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
+      "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ=="
     },
     "@types/ws": {
       "version": "0.0.42",
@@ -636,8 +652,7 @@
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
     "asn1": {
       "version": "0.1.11",
@@ -1333,7 +1348,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -1341,8 +1355,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
       "version": "0.3.0",
@@ -2165,8 +2178,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.8.1",
@@ -3226,7 +3238,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
-      "dev": true,
       "requires": {
         "parse-passwd": "1.0.0"
       }
@@ -4752,8 +4763,7 @@
     "make-error": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.2.tgz",
-      "integrity": "sha512-l9ra35l5VWLF24y75Tg8XgfGLX0ueRhph118WKM6H5denx4bB5QF59+4UAm9oJ2qsPQZas/CQUDdtDdfvYHBdQ==",
-      "dev": true
+      "integrity": "sha512-l9ra35l5VWLF24y75Tg8XgfGLX0ueRhph118WKM6H5denx4bB5QF59+4UAm9oJ2qsPQZas/CQUDdtDdfvYHBdQ=="
     },
     "make-error-cause": {
       "version": "1.2.2",
@@ -4896,14 +4906,12 @@
     "minimist": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-      "dev": true
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -4911,10 +4919,15 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
+    },
+    "mockery": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
+      "integrity": "sha512-9VkOmxKlWXoDO/h1jDZaS4lH33aWfRiJiNT/tKj+8OGzrcFDLo8d0syGdbsc3Bc4GvRXPb+NMMvojotmuGJTvA==",
+      "dev": true
     },
     "ms": {
       "version": "0.7.1",
@@ -5352,8 +5365,7 @@
     "parse-passwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
-      "dev": true
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
     },
     "parseurl": {
       "version": "1.3.2",
@@ -7516,6 +7528,21 @@
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
     },
+    "source-map-support": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.3.tgz",
+      "integrity": "sha512-eKkTgWYeBOQqFGXRfKabMFdnWepo51vWqEdoeikaEPFiJC7MCU5j2h4+6Q8npkZTeLGbSyecZvRxiSoWl3rh+w==",
+      "requires": {
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
+    },
     "spdx-correct": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
@@ -7696,8 +7723,7 @@
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "dev": true
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "supports-color": {
       "version": "2.0.0",
@@ -7997,6 +8023,74 @@
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
     },
+    "ts-node": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-4.1.0.tgz",
+      "integrity": "sha512-xcZH12oVg9PShKhy3UHyDmuDLV3y7iKwX25aMVPt1SIXSuAfWkFiGPEkg+th8R4YKW/QCxDoW7lJdb15lx6QWg==",
+      "requires": {
+        "arrify": "1.0.1",
+        "chalk": "2.3.0",
+        "diff": "3.4.0",
+        "make-error": "1.3.2",
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.5.3",
+        "tsconfig": "7.0.0",
+        "v8flags": "3.0.1",
+        "yn": "2.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "tsconfig": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
+      "integrity": "sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==",
+      "requires": {
+        "@types/strip-bom": "3.0.0",
+        "@types/strip-json-comments": "0.0.30",
+        "strip-bom": "3.0.0",
+        "strip-json-comments": "2.0.1"
+      },
+      "dependencies": {
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+        }
+      }
+    },
     "tslib": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.1.tgz",
@@ -8255,13 +8349,15 @@
           "dependencies": {
             "abbrev": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+              "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
               "dev": true,
               "optional": true
             },
             "ajv": {
               "version": "4.11.8",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+              "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8271,18 +8367,21 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
               "dev": true
             },
             "aproba": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
+              "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
               "dev": true,
               "optional": true
             },
             "are-we-there-yet": {
               "version": "1.1.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+              "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8292,42 +8391,49 @@
             },
             "asn1": {
               "version": "0.2.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+              "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
               "dev": true,
               "optional": true
             },
             "assert-plus": {
               "version": "0.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+              "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
               "dev": true,
               "optional": true
             },
             "asynckit": {
               "version": "0.4.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+              "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
               "dev": true,
               "optional": true
             },
             "aws-sign2": {
               "version": "0.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+              "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
               "dev": true,
               "optional": true
             },
             "aws4": {
               "version": "1.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+              "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
               "dev": true,
               "optional": true
             },
             "balanced-match": {
               "version": "0.4.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+              "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
               "dev": true
             },
             "bcrypt-pbkdf": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+              "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8336,7 +8442,8 @@
             },
             "block-stream": {
               "version": "0.0.9",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+              "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
               "dev": true,
               "requires": {
                 "inherits": "2.0.3"
@@ -8344,7 +8451,8 @@
             },
             "boom": {
               "version": "2.10.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+              "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
               "dev": true,
               "requires": {
                 "hoek": "2.16.3"
@@ -8352,7 +8460,8 @@
             },
             "brace-expansion": {
               "version": "1.1.7",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+              "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
               "dev": true,
               "requires": {
                 "balanced-match": "0.4.2",
@@ -8361,29 +8470,34 @@
             },
             "buffer-shims": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+              "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
               "dev": true
             },
             "caseless": {
               "version": "0.12.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+              "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
               "dev": true,
               "optional": true
             },
             "co": {
               "version": "4.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+              "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
               "dev": true,
               "optional": true
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
               "dev": true
             },
             "combined-stream": {
               "version": "1.0.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
               "dev": true,
               "requires": {
                 "delayed-stream": "1.0.0"
@@ -8391,22 +8505,26 @@
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
               "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
               "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
               "dev": true
             },
             "cryptiles": {
               "version": "2.0.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+              "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
               "dev": true,
               "requires": {
                 "boom": "2.10.1"
@@ -8414,7 +8532,8 @@
             },
             "dashdash": {
               "version": "1.14.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+              "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8423,7 +8542,8 @@
               "dependencies": {
                 "assert-plus": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                   "dev": true,
                   "optional": true
                 }
@@ -8431,7 +8551,8 @@
             },
             "debug": {
               "version": "2.6.8",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+              "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8440,30 +8561,35 @@
             },
             "deep-extend": {
               "version": "0.4.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+              "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
               "dev": true,
               "optional": true
             },
             "delayed-stream": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+              "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
               "dev": true
             },
             "delegates": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+              "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
               "dev": true,
               "optional": true
             },
             "detect-libc": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.2.tgz",
+              "integrity": "sha1-ca1dIEvxempsqPRQxhRUBm70YeE=",
               "dev": true,
               "optional": true
             },
             "ecc-jsbn": {
               "version": "0.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+              "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8472,24 +8598,28 @@
             },
             "extend": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+              "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
               "dev": true,
               "optional": true
             },
             "extsprintf": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+              "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
               "dev": true
             },
             "forever-agent": {
               "version": "0.6.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+              "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
               "dev": true,
               "optional": true
             },
             "form-data": {
               "version": "2.1.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+              "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8500,12 +8630,14 @@
             },
             "fs.realpath": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
               "dev": true
             },
             "fstream": {
               "version": "1.0.11",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+              "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
               "dev": true,
               "requires": {
                 "graceful-fs": "4.1.11",
@@ -8516,7 +8648,8 @@
             },
             "fstream-ignore": {
               "version": "1.0.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+              "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8527,7 +8660,8 @@
             },
             "gauge": {
               "version": "2.7.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+              "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8543,7 +8677,8 @@
             },
             "getpass": {
               "version": "0.1.7",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+              "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8552,7 +8687,8 @@
               "dependencies": {
                 "assert-plus": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                   "dev": true,
                   "optional": true
                 }
@@ -8560,7 +8696,8 @@
             },
             "glob": {
               "version": "7.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+              "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
               "dev": true,
               "requires": {
                 "fs.realpath": "1.0.0",
@@ -8573,18 +8710,21 @@
             },
             "graceful-fs": {
               "version": "4.1.11",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+              "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
               "dev": true
             },
             "har-schema": {
               "version": "1.0.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+              "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
               "dev": true,
               "optional": true
             },
             "har-validator": {
               "version": "4.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+              "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8594,13 +8734,15 @@
             },
             "has-unicode": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+              "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
               "dev": true,
               "optional": true
             },
             "hawk": {
               "version": "3.1.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+              "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
               "dev": true,
               "requires": {
                 "boom": "2.10.1",
@@ -8611,12 +8753,14 @@
             },
             "hoek": {
               "version": "2.16.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+              "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
               "dev": true
             },
             "http-signature": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+              "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8627,7 +8771,8 @@
             },
             "inflight": {
               "version": "1.0.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
               "dev": true,
               "requires": {
                 "once": "1.4.0",
@@ -8636,18 +8781,21 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
               "dev": true
             },
             "ini": {
               "version": "1.3.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+              "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
               "dev": true,
               "optional": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
               "requires": {
                 "number-is-nan": "1.0.1"
@@ -8655,24 +8803,28 @@
             },
             "is-typedarray": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+              "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
               "dev": true,
               "optional": true
             },
             "isarray": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
               "dev": true
             },
             "isstream": {
               "version": "0.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
               "dev": true,
               "optional": true
             },
             "jodid25519": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+              "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8681,19 +8833,22 @@
             },
             "jsbn": {
               "version": "0.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+              "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
               "dev": true,
               "optional": true
             },
             "json-schema": {
               "version": "0.2.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+              "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
               "dev": true,
               "optional": true
             },
             "json-stable-stringify": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+              "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8702,19 +8857,22 @@
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
               "dev": true,
               "optional": true
             },
             "jsonify": {
               "version": "0.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+              "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
               "dev": true,
               "optional": true
             },
             "jsprim": {
               "version": "1.4.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+              "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8726,7 +8884,8 @@
               "dependencies": {
                 "assert-plus": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                   "dev": true,
                   "optional": true
                 }
@@ -8734,12 +8893,14 @@
             },
             "mime-db": {
               "version": "1.27.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+              "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
               "dev": true
             },
             "mime-types": {
               "version": "2.1.15",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+              "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
               "dev": true,
               "requires": {
                 "mime-db": "1.27.0"
@@ -8747,7 +8908,8 @@
             },
             "minimatch": {
               "version": "3.0.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
               "requires": {
                 "brace-expansion": "1.1.7"
@@ -8755,12 +8917,14 @@
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
               "dev": true
             },
             "mkdirp": {
               "version": "0.5.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "dev": true,
               "requires": {
                 "minimist": "0.0.8"
@@ -8768,13 +8932,15 @@
             },
             "ms": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
               "dev": true,
               "optional": true
             },
             "node-pre-gyp": {
               "version": "0.6.39",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz",
+              "integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8793,7 +8959,8 @@
             },
             "nopt": {
               "version": "4.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+              "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8803,7 +8970,8 @@
             },
             "npmlog": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
+              "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8815,24 +8983,28 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
               "dev": true
             },
             "oauth-sign": {
               "version": "0.8.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+              "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
               "dev": true,
               "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
               "dev": true,
               "optional": true
             },
             "once": {
               "version": "1.4.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "dev": true,
               "requires": {
                 "wrappy": "1.0.2"
@@ -8840,19 +9012,22 @@
             },
             "os-homedir": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
               "dev": true,
               "optional": true
             },
             "os-tmpdir": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+              "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
               "dev": true,
               "optional": true
             },
             "osenv": {
               "version": "0.1.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+              "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8862,35 +9037,41 @@
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
               "dev": true
             },
             "performance-now": {
               "version": "0.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+              "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
               "dev": true,
               "optional": true
             },
             "process-nextick-args": {
               "version": "1.0.7",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+              "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
               "dev": true
             },
             "punycode": {
               "version": "1.4.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+              "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
               "dev": true,
               "optional": true
             },
             "qs": {
               "version": "6.4.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+              "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
               "dev": true,
               "optional": true
             },
             "rc": {
               "version": "1.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+              "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8902,7 +9083,8 @@
               "dependencies": {
                 "minimist": {
                   "version": "1.2.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                   "dev": true,
                   "optional": true
                 }
@@ -8910,7 +9092,8 @@
             },
             "readable-stream": {
               "version": "2.2.9",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+              "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
               "dev": true,
               "requires": {
                 "buffer-shims": "1.0.0",
@@ -8924,7 +9107,8 @@
             },
             "request": {
               "version": "2.81.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+              "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8954,7 +9138,8 @@
             },
             "rimraf": {
               "version": "2.6.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+              "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
               "dev": true,
               "requires": {
                 "glob": "7.1.2"
@@ -8962,30 +9147,35 @@
             },
             "safe-buffer": {
               "version": "5.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+              "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
               "dev": true
             },
             "semver": {
               "version": "5.3.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+              "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
               "dev": true,
               "optional": true
             },
             "set-blocking": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
               "dev": true,
               "optional": true
             },
             "signal-exit": {
               "version": "3.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+              "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
               "dev": true,
               "optional": true
             },
             "sntp": {
               "version": "1.0.9",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+              "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
               "dev": true,
               "requires": {
                 "hoek": "2.16.3"
@@ -8993,7 +9183,8 @@
             },
             "sshpk": {
               "version": "1.13.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+              "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -9010,7 +9201,8 @@
               "dependencies": {
                 "assert-plus": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                   "dev": true,
                   "optional": true
                 }
@@ -9018,7 +9210,8 @@
             },
             "string-width": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
                 "code-point-at": "1.1.0",
@@ -9028,7 +9221,8 @@
             },
             "string_decoder": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+              "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
               "dev": true,
               "requires": {
                 "safe-buffer": "5.0.1"
@@ -9036,13 +9230,15 @@
             },
             "stringstream": {
               "version": "0.0.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+              "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
               "dev": true,
               "optional": true
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "requires": {
                 "ansi-regex": "2.1.1"
@@ -9050,13 +9246,15 @@
             },
             "strip-json-comments": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+              "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
               "dev": true,
               "optional": true
             },
             "tar": {
               "version": "2.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+              "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
               "dev": true,
               "requires": {
                 "block-stream": "0.0.9",
@@ -9066,7 +9264,8 @@
             },
             "tar-pack": {
               "version": "3.4.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
+              "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -9082,7 +9281,8 @@
             },
             "tough-cookie": {
               "version": "2.3.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+              "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -9091,7 +9291,8 @@
             },
             "tunnel-agent": {
               "version": "0.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+              "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -9100,30 +9301,35 @@
             },
             "tweetnacl": {
               "version": "0.14.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+              "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
               "dev": true,
               "optional": true
             },
             "uid-number": {
               "version": "0.0.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+              "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
               "dev": true,
               "optional": true
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
               "dev": true
             },
             "uuid": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+              "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
               "dev": true,
               "optional": true
             },
             "verror": {
               "version": "1.3.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+              "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -9132,7 +9338,8 @@
             },
             "wide-align": {
               "version": "1.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+              "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -9141,7 +9348,8 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
               "dev": true
             }
           }
@@ -9691,6 +9899,14 @@
       "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
       "dev": true
     },
+    "v8flags": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.0.1.tgz",
+      "integrity": "sha1-3Oj8N5wX2fLJ6e142JzgAFKxt2s=",
+      "requires": {
+        "homedir-polyfill": "1.0.1"
+      }
+    },
     "validate-npm-package-license": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
@@ -9936,6 +10152,11 @@
         "buffer-crc32": "0.2.13",
         "fd-slicer": "1.0.1"
       }
+    },
+    "yn": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
+      "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo="
     },
     "zip-object": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "css-select-umd": "1.3.0-rc0",
     "diff": "3.4.0",
+    "ts-node": "^4.1.0",
     "tslib": "~1.8.1"
   },
   "devDependencies": {
@@ -46,6 +47,7 @@
     "@types/glob": "5.0.*",
     "@types/grunt": "0.4.*",
     "@types/jsdom": "2.0.*",
+    "@types/mockery": "^1.4.29",
     "@types/sinon": "^1.16.31",
     "grunt": "~1.0.1",
     "grunt-dojo2": "latest",
@@ -53,6 +55,7 @@
     "husky": "0.14.3",
     "intern": "~4.1.0",
     "lint-staged": "6.0.0",
+    "mockery": "^2.1.0",
     "prettier": "1.9.2",
     "sinon": "^2.2.0",
     "tslint": "5.8.0",

--- a/src/plugins/postcssRequirePlugin.ts
+++ b/src/plugins/postcssRequirePlugin.ts
@@ -1,0 +1,17 @@
+import Node from 'intern/lib/executors/Node';
+
+declare const intern: Node;
+
+/**
+ * PostCSS Intern plugin for Node.js
+ *
+ * This plugin augments Node.js's `require` method to allow for run-time loading and compiling of css files
+ */
+intern.registerPlugin('postcss-node', (options: any = {}) => {
+	if (intern.environment !== 'node') {
+		intern.emit('warning', 'postcss-require-plugin cannot run outside of a nodejs environment');
+	}
+
+	const hook = require('css-modules-require-hook');
+	hook(options);
+});

--- a/src/plugins/postcssRequirePlugin.ts
+++ b/src/plugins/postcssRequirePlugin.ts
@@ -2,14 +2,16 @@ import Node from 'intern/lib/executors/Node';
 
 declare const intern: Node;
 
+const PLUGIN_NAME = 'postcss-node';
+
 /**
  * PostCSS Intern plugin for Node.js
  *
  * This plugin augments Node.js's `require` method to allow for run-time loading and compiling of css files
  */
-intern.registerPlugin('postcss-node', (options: any = {}) => {
+intern.registerPlugin(PLUGIN_NAME, (options: any = {}) => {
 	if (intern.environment !== 'node') {
-		intern.emit('warning', 'postcss-require-plugin cannot run outside of a nodejs environment');
+		intern.emit('warning', `${PLUGIN_NAME} cannot run outside of a nodejs environment`);
 	}
 
 	const hook = require('css-modules-require-hook');

--- a/src/plugins/tsnodePlugin.ts
+++ b/src/plugins/tsnodePlugin.ts
@@ -2,14 +2,16 @@ import Node from 'intern/lib/executors/Node';
 
 declare const intern: Node;
 
+const PLUGIN_NAME = 'ts-node';
+
 /**
  * TypeScript Intern plugin for Node.js
  *
  * This plugin augments Node.js's `require` method to allow for run-time loading and compiling of TypeScript files
  */
-intern.registerPlugin('ts-node', (options?: any) => {
+intern.registerPlugin(PLUGIN_NAME, (options?: any) => {
 	if (intern.environment !== 'node') {
-		intern.emit('warning', 'postcss-require-plugin cannot run outside of a nodejs environment');
+		intern.emit('warning', `${PLUGIN_NAME} cannot run outside of a nodejs environment`);
 	}
 
 	const tsnode = require('ts-node');

--- a/src/plugins/tsnodePlugin.ts
+++ b/src/plugins/tsnodePlugin.ts
@@ -1,0 +1,17 @@
+import Node from 'intern/lib/executors/Node';
+
+declare const intern: Node;
+
+/**
+ * TypeScript Intern plugin for Node.js
+ *
+ * This plugin augments Node.js's `require` method to allow for run-time loading and compiling of TypeScript files
+ */
+intern.registerPlugin('ts-node', (options?: any) => {
+	if (intern.environment !== 'node') {
+		intern.emit('warning', 'postcss-require-plugin cannot run outside of a nodejs environment');
+	}
+
+	const tsnode = require('ts-node');
+	options ? tsnode.register(options) : tsnode.register();
+});

--- a/tests/support/mockUtil.ts
+++ b/tests/support/mockUtil.ts
@@ -1,0 +1,22 @@
+import * as mockery from 'mockery';
+
+export interface MockMap {
+	[key: string]: any;
+}
+
+export function mock(mocks: MockMap) {
+	mockery.enable({
+		useCleanCache: true,
+		warnOnReplace: false,
+		warnOnUnregistered: false
+	});
+	for (let moduleId in mocks) {
+		const moduleContents = mocks[moduleId];
+		mockery.registerMock(moduleId, moduleContents);
+	}
+}
+
+export function unmock() {
+	mockery.deregisterAll();
+	mockery.disable();
+}

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -1,3 +1,4 @@
 import './harness';
 import './harnessWithTsx';
+import './plugins/all';
 import './support/all';

--- a/tests/unit/plugins/all.ts
+++ b/tests/unit/plugins/all.ts
@@ -1,0 +1,2 @@
+import './postcssRequirePlugin';
+import './tsnodePlugin';

--- a/tests/unit/plugins/all.ts
+++ b/tests/unit/plugins/all.ts
@@ -1,2 +1,5 @@
-import './postcssRequirePlugin';
-import './tsnodePlugin';
+if (intern.environment === 'node') {
+	// These node.js specific tests have node-only dependencies (i.e. mockery)
+	require('./postcssRequirePlugin');
+	require('./tsnodePlugin');
+}

--- a/tests/unit/plugins/postcssRequirePlugin.ts
+++ b/tests/unit/plugins/postcssRequirePlugin.ts
@@ -1,0 +1,56 @@
+import { SinonStub, stub } from 'sinon';
+import { mock, unmock } from '../../support/mockUtil';
+
+const { registerSuite } = intern.getInterface('object');
+const { assert } = intern.getPlugin('chai');
+
+let moduleStub: SinonStub;
+let registerPluginStub: SinonStub;
+
+function assertRegisterPlugin() {
+	assert.strictEqual(registerPluginStub.callCount, 1);
+	const callback = registerPluginStub.lastCall.args[1];
+	assert.strictEqual(moduleStub.callCount, 0);
+	assert.isFunction(callback);
+
+	return callback;
+}
+
+registerSuite('plugins/postcssRequirePlugin', {
+	afterEach() {
+		unmock();
+		registerPluginStub.restore();
+	},
+
+	beforeEach(test) {
+		if (intern.environment !== 'node') {
+			test.skip('postcssRequirePlugin only runs in a node environment');
+		} else {
+			moduleStub = stub();
+			mock({
+				'css-modules-require-hook': moduleStub
+			});
+			registerPluginStub = stub(intern, 'registerPlugin');
+			require('../../../src/plugins/postcssRequirePlugin');
+		}
+	},
+
+	tests: {
+		'plugin loads without options'() {
+			const callback = assertRegisterPlugin();
+			callback();
+
+			assert.strictEqual(moduleStub.callCount, 1);
+			assert.deepEqual(moduleStub.lastCall.args[0], {});
+		},
+
+		'plugin loads and passes options'() {
+			const callback = assertRegisterPlugin();
+			const options = {};
+			callback(options);
+
+			assert.strictEqual(moduleStub.callCount, 1);
+			assert.equal(moduleStub.lastCall.args[0], options);
+		}
+	}
+});

--- a/tests/unit/plugins/postcssRequirePlugin.ts
+++ b/tests/unit/plugins/postcssRequirePlugin.ts
@@ -51,6 +51,24 @@ registerSuite('plugins/postcssRequirePlugin', {
 
 			assert.strictEqual(moduleStub.callCount, 1);
 			assert.equal(moduleStub.lastCall.args[0], options);
+		},
+
+		'not a node environment; warns'() {
+			const oldIntern = intern;
+			const mockIntern = {
+				emit: stub(),
+				environment: 'tacos'
+			};
+			try {
+				(<any>global).intern = mockIntern;
+				const callback = registerPluginStub.lastCall.args[1];
+				callback();
+				(<any>global).intern = oldIntern;
+				assert.strictEqual(mockIntern.emit.callCount, 1);
+				assert.strictEqual(mockIntern.emit.lastCall.args[0], 'warning');
+			} finally {
+				(<any>global).intern = oldIntern;
+			}
 		}
 	}
 });

--- a/tests/unit/plugins/tsnodePlugin.ts
+++ b/tests/unit/plugins/tsnodePlugin.ts
@@ -1,0 +1,58 @@
+import { SinonStub, stub } from 'sinon';
+import { mock, unmock } from '../../support/mockUtil';
+
+const { registerSuite } = intern.getInterface('object');
+const { assert } = intern.getPlugin('chai');
+
+let registerStub: SinonStub;
+let registerPluginStub: SinonStub;
+
+function assertRegisterPlugin() {
+	assert.strictEqual(registerPluginStub.callCount, 1);
+	const callback = registerPluginStub.lastCall.args[1];
+	assert.strictEqual(registerStub.callCount, 0);
+	assert.isFunction(callback);
+
+	return callback;
+}
+
+registerSuite('plugins/tsnodePlugin', {
+	afterEach() {
+		unmock();
+		registerPluginStub.restore();
+	},
+
+	beforeEach(test) {
+		if (intern.environment !== 'node') {
+			test.skip('postcssRequirePlugin only runs in a node environment');
+		} else {
+			registerStub = stub();
+			mock({
+				'ts-node': { register: registerStub }
+			});
+			registerPluginStub = stub(intern, 'registerPlugin');
+			require('../../../src/plugins/tsnodePlugin');
+		}
+	},
+
+	tests: {
+		'plugin loads without options'() {
+			const callback = assertRegisterPlugin();
+
+			callback();
+
+			assert.strictEqual(registerStub.callCount, 1);
+			assert.lengthOf(registerStub.lastCall.args, 0);
+		},
+
+		'plugin loads and passes options'() {
+			const callback = assertRegisterPlugin();
+
+			const options = {};
+			callback(options);
+
+			assert.strictEqual(registerStub.callCount, 1);
+			assert.equal(registerStub.lastCall.args[0], options);
+		}
+	}
+});

--- a/tests/unit/plugins/tsnodePlugin.ts
+++ b/tests/unit/plugins/tsnodePlugin.ts
@@ -53,6 +53,24 @@ registerSuite('plugins/tsnodePlugin', {
 
 			assert.strictEqual(registerStub.callCount, 1);
 			assert.equal(registerStub.lastCall.args[0], options);
+		},
+
+		'not a node environment; warns'() {
+			const oldIntern = intern;
+			const mockIntern = {
+				emit: stub(),
+				environment: 'tacos'
+			};
+			try {
+				(<any>global).intern = mockIntern;
+				const callback = registerPluginStub.lastCall.args[1];
+				callback();
+				(<any>global).intern = oldIntern;
+				assert.strictEqual(mockIntern.emit.callCount, 1);
+				assert.strictEqual(mockIntern.emit.lastCall.args[0], 'warning');
+			} finally {
+				(<any>global).intern = oldIntern;
+			}
 		}
 	}
 });


### PR DESCRIPTION
**Type:** feature

**Description:**

Adds Intern plugins that run [ts-node](https://www.npmjs.com/package/ts-node) and [css-modules-require-hook](https://github.com/css-modules/css-modules-require-hook) to support JIT compiling of TypeScript and CSS requires during tests.

Related dojo/cli-test-intern#83
